### PR TITLE
Support Rust 1.12.1

### DIFF
--- a/src/span_of.rs
+++ b/src/span_of.rs
@@ -132,7 +132,7 @@ macro_rules! span_of {
 
 #[cfg(test)]
 mod tests {
-    use ::*;
+    use std::mem;
 
     #[repr(C, packed)]
     struct Foo {


### PR DESCRIPTION
Hi!  First of all, thank you for maintaining this extremely useful library!

Currently, `memoffset` is used by [`crossbeam-epoch`](https://github.com/crossbeam-rs/crossbeam-epoch), which is a concurrency library.  We Crossbeam developers aim to [push it](https://github.com/rayon-rs/rayon/pull/480) to [`rayon`](https://github.com/rayon-rs/rayon), which is a parallelism library.

But `rayon` should support Rust 1.12, and `memoffset` currently doesn't.  May I ask if you could merge this PR so that `memoffset` can be compiled in Rust 1.12.1, and in turn `rayon` can depend on `crossbeam-epoch`?