### PR TITLE
Add #[allow(const_err)] on test offset_index_out_of_bounds

### DIFF
--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -105,6 +105,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[allow(const_err)]
     fn offset_index_out_of_bounds() {
         offset_of!(Foo, b[4]);
     }


### PR DESCRIPTION
The compiler now raises a deny-by-default `const_err` lint on this test,
which doesn't let it get to the expected `#[should_panic]`.  We can
allow that lint in order to let the test hit the error it wants.