### PR TITLE
Support const expr (but not const fns) and arbitrary expressions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@
 //!
 //! Some of the funcationality of the crate makes no sense when used along with structs that
 //! are not `#[repr(C, packed)]`, but it is up to the user to make sure that they are.
+//! 
+//! This functionality should work for `const`s but presently doesn't work on `const fn`. Storing a
+//! value in a const and then returning it from a `const fn` should workaround most cases.
 //!
 //! ## Examples
 //! ```
@@ -63,6 +66,19 @@
 // Doing this enables this crate to function under both std and no-std crates.
 #[doc(hidden)]
 pub use core::mem;
+
+// A helper to get a const fn version of size_of_val 
+#[doc(hidden)]
+pub const fn size_of<T>(_: &T) -> usize { mem::size_of::<T>() }
+
+// While constant pointer transmutation isn't stable, union transmutation is
+// This hack should go away after rust-lang/rust#51910
+#[doc(hidden)]
+pub union Transmuter<T: 'static> {
+    pub ptr: &'static T,
+    pub int: usize,
+}
+
 
 #[macro_use]
 mod offset_of;

--- a/src/span_of.rs
+++ b/src/span_of.rs
@@ -44,8 +44,15 @@
 /// ```
 ///
 /// *Note*: 
-/// This macro uses recursion in order to resolve the range expressions, so there is a limit to the complexity of the expression.
-/// In order to raise the limit, the compiler's recursion limit should be lifted.
+/// This macro uses recursion in order to resolve the range expressions, so there is a limit to the
+/// complexity of the expression.
+/// 
+/// It also supports a lambda-like notation for completely arbitrary expressions like:
+/// `(x -> &x.foo)..(x -> &x.bar[1])`
+///
+/// These expressions are more powerful, and are not subject to the recursion limit. Each lambda
+/// should act as though it is taking a static reference to an uninitialized object and returning
+/// a reference to a field within that same object.
 ///
 /// *Note*: 
 /// This macro may not make much sense when used on structs that are not `#[repr(C, packed)]`
@@ -81,53 +88,86 @@
 /// ```
 #[macro_export]
 macro_rules! span_of {
-    (@helper $root:ident, [] ..=) => {
+    (@helper $parent:ty, $id:ident -> $start:expr, $end:expr) => (unsafe {        
+        let $id: &'static $parent = $crate::Transmuter::<$parent> { int: 0 }.ptr;
+        let start = $crate::Transmuter { ptr: $start }.int;
+        start..$end
+    });
+
+    (@helper $parent:ty, $id:ident -> $start:expr, $id2:ident -> $end:expr, $extra:expr) => (
+        span_of!(@helper $parent, $id -> $start, {
+            let $id2 = $id;
+            let end = $crate::Transmuter { ptr: $end }.int;
+            end + $extra
+        })
+    );
+
+    (@helper $parent:ty, [] ..=) => (
         compile_error!("Expected a range, found '..='")
-    };
-    (@helper $root:ident, [] ..) => {
+    );
+    (@helper $parent:ty, [] ..) => (
         compile_error!("Expected a range, found '..'")
-    };
-    (@helper $root:ident, [] ..= $($field:tt)+) => {
-        (&$root as *const _ as usize,
-         &$root.$($field)* as *const _ as usize + $crate::mem::size_of_val(&$root.$($field)*))
-    };
-    (@helper $root:ident, [] .. $($field:tt)+) => {
-        (&$root as *const _ as usize, &$root.$($field)* as *const _ as usize)
-    };
-    (@helper $root:ident, $(# $begin:tt)+ [] ..= $($end:tt)+) => {
-        (&$root.$($begin)* as *const _ as usize,
-         &$root.$($end)* as *const _ as usize + $crate::mem::size_of_val(&$root.$($end)*))
-    };
-    (@helper $root:ident, $(# $begin:tt)+ [] .. $($end:tt)+) => {
-        (&$root.$($begin)* as *const _ as usize, &$root.$($end)* as *const _ as usize)
-    };
-    (@helper $root:ident, $(# $begin:tt)+ [] ..) => {
-        (&$root.$($begin)* as *const _ as usize,
-         &$root as *const _ as usize + $crate::mem::size_of_val(&$root))
-    };
-    (@helper $root:ident, $(# $begin:tt)+ [] ..=) => {
+    );
+    (@helper $parent:ty, [] ..= $($field:tt)+) => (
+        span_of!($parent, ..=(x -> &x.$($field)*))
+    );
+    (@helper $parent:ty, [] .. $($field:tt)+) => (
+        span_of!($parent, ..(x -> &x.$($field)*))
+    );
+    (@helper $parent:ty, $(# $begin:tt)+ [] ..= $($end:tt)+) => (
+        span_of!($parent, (x -> &x.$($begin)*)..=(x -> &x.$($end)*))
+    );
+    (@helper $parent:ty, $(# $begin:tt)+ [] .. $($end:tt)+) => (
+        span_of!($parent, (x -> &x.$($begin)*)..(x -> &x.$($end)*))
+    );
+    (@helper $parent:ty, $(# $begin:tt)+ [] ..) => (
+        span_of!($parent, x -> &x.$($begin)*)
+    );
+    (@helper $parent:ty, $(# $begin:tt)+ [] ..=) => {
         compile_error!(
             "Found inclusive range to the end of a struct. Did you mean '..' instead of '..='?")
     };
-    (@helper $root:ident, $(# $begin:tt)+ []) => {
-        (&$root.$($begin)* as *const _ as usize,
-         &$root.$($begin)* as *const _ as usize + $crate::mem::size_of_val(&$root.$($begin)*))
+    (@helper $parent:ty, $(# $begin:tt)+ [] ) => (
+        span_of!($parent, (x -> &x.$($begin)*)..=(x -> &x.$($begin)*))
+    );
+    (@helper $parent:ty, $(# $begin:tt)+ [] $tt:tt $($rest:tt)*) => {
+        span_of!(@helper $parent, $(#$begin)* #$tt [] $($rest)*)
     };
-    (@helper $root:ident, $(# $begin:tt)+ [] $tt:tt $($rest:tt)*) => {
-        span_of!(@helper $root, $(#$begin)* #$tt [] $($rest)*)
-    };
-    (@helper $root:ident, [] $tt:tt $($rest:tt)*) => {
-        span_of!(@helper $root, #$tt [] $($rest)*)
+    (@helper $parent:ty, [] $tt:tt $($rest:tt)*) => {
+        span_of!(@helper $parent, #$tt [] $($rest)*)
     };
 
-    ($sty:ty, $($exp:tt)+) => ({
-        unsafe { 
-            let root: $sty = $crate::mem::uninitialized();
-            let base = &root as *const _ as usize;
-            let (begin, end) = span_of!(@helper root, [] $($exp)*);
-            begin-base..end-base
-        }
-    });
+
+    ($parent:ty,  .. ($id2:ident -> $end:expr)) => (
+        span_of!(@helper $parent, x -> x, $id2 -> $end, 0)
+    );
+    ($parent:ty,  ..= ($id2:ident -> $end:expr)) => (
+        span_of!(@helper $parent, x -> x, $id2 -> $end, $crate::size_of($end))
+    );
+
+    ($parent:ty, $id:ident -> $start:expr) => (
+        span_of!(@helper $parent, $id -> $start, $crate::mem::size_of::<$parent>())
+    );
+
+    ($parent:ty, ($id:ident -> $start:expr)..) => (
+        span_of!($parent, $id -> $start)
+    );
+    ($parent:ty, ($id:ident -> $start:expr) .. ($id2:ident -> $end:expr)) => (
+        span_of!(@helper $parent, $id -> $start, $id2 -> $end, 0)
+    );
+    ($parent:ty, ($id:ident -> $start:expr) ..= ($id2:ident -> $end:expr)) => (
+        span_of!(@helper $parent, $id -> $start, $id2 -> $end, $crate::size_of($end))
+    );
+    
+    ($parent:ty, ($id:ident -> $start:expr) .. ) => (
+        compile_error!("Expected a range, found '..'")
+    );
+    ($parent:ty, ($id:ident -> $start:expr) ..= ) => (
+        compile_error!("Expected a range, found '..='")
+    );
+
+
+    ($parent:ty, $($exp:tt)+) => (span_of!(@helper $parent, [] $($exp)*));
 }
 
 #[cfg(test)]
@@ -139,6 +179,13 @@ mod tests {
         a: u32,
         b: [u8; 4],
         c: i64,
+    }
+
+    #[test]
+    fn span_integer() {
+        assert_eq!(span_of!(u32, x -> x), 0..4);
+        assert_eq!(span_of!(u32, (x -> x)..(x -> x)), 0..0);
+        assert_eq!(span_of!(u32, (x -> x)..=(x -> x)), 0..4);
     }
 
     #[test]


### PR DESCRIPTION
Parse `expr`s using lambda like syntax to avoid recursion.