### PR TITLE
Fix span_of

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! fn main() {
 //!     assert_eq!(offset_of!(HelpMeIAmTrappedInAStructFactory, a), 15);
 //!     assert_eq!(span_of!(HelpMeIAmTrappedInAStructFactory, a), 15..19);
-//!     assert_eq!(span_of!(HelpMeIAmTrappedInAStructFactory, help_me_before_they_[2] .. a), 2..15);
+//!     assert_eq!(span_of!(HelpMeIAmTrappedInAStructFactory, help_me_before_they_ .. a), 0..15);
 //! }
 //! ```
 //!

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -76,10 +76,10 @@ macro_rules! field_check {
 #[macro_export]
 macro_rules! offset_of {
     ($parent:tt, $field:tt) => {{
-        $crate::field_check!($parent, $field);
+        field_check!($parent, $field);
 
         // Get a base pointer.
-        $crate::let_base_ptr!(base_ptr, $parent);
+        let_base_ptr!(base_ptr, $parent);
         // Get the field address. This is UB because we are creating a reference to
         // the uninitialized field.
         #[allow(unused_unsafe)] // for when the macro is used in an unsafe block

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -89,25 +89,41 @@ macro_rules! offset_of {
 
 #[cfg(test)]
 mod tests {
-    #[repr(C, packed)]
-    struct Foo {
-        a: u32,
-        b: [u8; 4],
-        c: i64,
-    }
-
     #[test]
     fn offset_simple() {
+        #[repr(C)]
+        struct Foo {
+            a: u32,
+            b: [u8; 2],
+            c: i64,
+        }
+
         assert_eq!(offset_of!(Foo, a), 0);
         assert_eq!(offset_of!(Foo, b), 4);
         assert_eq!(offset_of!(Foo, c), 8);
     }
 
     #[test]
-    fn tuple_struct() {
+    #[cfg(not(miri))] // this creates unaligned references
+    fn offset_simple_packed() {
         #[repr(C, packed)]
+        struct Foo {
+            a: u32,
+            b: [u8; 2],
+            c: i64,
+        }
+
+        assert_eq!(offset_of!(Foo, a), 0);
+        assert_eq!(offset_of!(Foo, b), 4);
+        assert_eq!(offset_of!(Foo, c), 6);
+    }
+
+    #[test]
+    fn tuple_struct() {
+        #[repr(C)]
         struct Tup(i32, i32);
 
         assert_eq!(offset_of!(Tup, 0), 0);
+        assert_eq!(offset_of!(Tup, 1), 4);
     }
 }

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -42,6 +42,18 @@ macro_rules! let_base_ptr {
     }
 }
 
+/// Deref-coercion protection macro.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! field_check {
+    ($type:tt, $field:tt) => {
+        // Make sure the field actually exists. This line ensures that a
+        // compile-time error is generated if $field is accessed through a
+        // Deref impl.
+        let $type { $field: _, .. };
+    }
+}
+
 /// Calculates the offset of the specified field from the start of the struct.
 /// This macro supports arbitrary amount of subscripts and recursive member-accesses.
 ///
@@ -67,10 +79,7 @@ macro_rules! let_base_ptr {
 #[macro_export]
 macro_rules! offset_of {
     ($parent:tt, $field:tt) => {{
-        // Make sure the field actually exists. This line ensures that a
-        // compile-time error is generated if $field is accessed through a
-        // Deref impl.
-        let $parent { $field: _, .. };
+        field_check!($parent, $field);
 
         // Get a base pointer.
         $crate::let_base_ptr!(base_ptr, $parent);

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -28,7 +28,7 @@ macro_rules! let_base_ptr {
         // No UB here, and the pointer does not dangle, either.
         let uninit = $crate::mem::MaybeUninit::<$type>::uninit();
         let $name = uninit.as_ptr();
-    }
+    };
 }
 #[cfg(not(memoffset_maybe_uninit))]
 #[macro_export]
@@ -39,7 +39,7 @@ macro_rules! let_base_ptr {
         // of this pointer, and that is UB when the pointer is dangling.
         let non_null = $crate::ptr::NonNull::<$type>::dangling();
         let $name = non_null.as_ptr() as *const $type;
-    }
+    };
 }
 
 /// Deref-coercion protection macro.
@@ -51,7 +51,7 @@ macro_rules! field_check {
         // compile-time error is generated if $field is accessed through a
         // Deref impl.
         let $type { $field: _, .. };
-    }
+    };
 }
 
 /// Calculates the offset of the specified field from the start of the struct.

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -26,6 +26,10 @@
 macro_rules! let_base_ptr {
     ($name:ident, $type:tt) => {
         // No UB here, and the pointer does not dangle, either.
+        // But we have to make sure that `uninit` lives long enough,
+        // so it has to be in the same scope as `$name`. That's why
+        // `let_base_ptr` declares a variable (several, actually)
+        // instad of returning one.
         let uninit = $crate::mem::MaybeUninit::<$type>::uninit();
         let $name = uninit.as_ptr();
     };

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -76,7 +76,7 @@ macro_rules! field_check {
 #[macro_export]
 macro_rules! offset_of {
     ($parent:tt, $field:tt) => {{
-        field_check!($parent, $field);
+        $crate::field_check!($parent, $field);
 
         // Get a base pointer.
         $crate::let_base_ptr!(base_ptr, $parent);

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -55,9 +55,6 @@ macro_rules! field_check {
 }
 
 /// Calculates the offset of the specified field from the start of the struct.
-/// This macro supports arbitrary amount of subscripts and recursive member-accesses.
-///
-/// *Note*: This macro may not make much sense when used on structs that are not `#[repr(C, packed)]`
 ///
 /// ## Examples
 /// ```

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -18,6 +18,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+/// Macro to create a local `base_ptr` raw pointer of the given type, avoiding UB as
+/// much as is possible currently.
+#[cfg(memoffset_maybe_uninit)]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! let_base_ptr {
+    ($name:ident, $type:tt) => {
+        // No UB here, and the pointer does not dangle, either.
+        let uninit = $crate::mem::MaybeUninit::<$type>::uninit();
+        let $name = uninit.as_ptr();
+    }
+}
+#[cfg(not(memoffset_maybe_uninit))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! let_base_ptr {
+    ($name:ident, $type:tt) => {
+        // No UB right here, but we will later offset into a field
+        // of this pointer, and that is UB when the pointer is dangling.
+        let non_null = $crate::ptr::NonNull::<$type>::dangling();
+        let $name = non_null.as_ptr() as *const $type;
+    }
+}
+
 /// Calculates the offset of the specified field from the start of the struct.
 /// This macro supports arbitrary amount of subscripts and recursive member-accesses.
 ///
@@ -41,7 +65,6 @@
 /// }
 /// ```
 #[macro_export]
-#[cfg(memoffset_maybe_uninit)]
 macro_rules! offset_of {
     ($parent:tt, $field:tt) => {{
         // Make sure the field actually exists. This line ensures that a
@@ -49,38 +72,11 @@ macro_rules! offset_of {
         // Deref impl.
         let $parent { $field: _, .. };
 
-        // Create an instance of the container and calculate the offset to its field.
-        // Here we're using an uninitialized instance of $parent.
-        // Since we're not using its field, there's no UB caused by reading uninitialized memory.
-        // There *IS*, though, UB caused by creating references to uninitialized data,
-        // which is illegal since the compiler is allowed to assume that a reference
-        // points to valid data.
-        // However, currently we just cannot avoid UB completely.
-        let val = $crate::mem::MaybeUninit::<$parent>::uninit();
-        let base_ptr = val.as_ptr();
+        // Get a base pointer.
+        $crate::let_base_ptr!(base_ptr, $parent);
+        // Get the field address. This is UB because we are creating a reference to
+        // the uninitialized field.
         #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
-        let field_ptr = unsafe { &(*base_ptr).$field as *const _ };
-        let offset = (field_ptr as usize) - (base_ptr as usize);
-        offset
-    }};
-}
-
-#[macro_export]
-#[cfg(not(memoffset_maybe_uninit))]
-macro_rules! offset_of {
-    ($parent:tt, $field:tt) => {{
-        // Make sure the field actually exists. This line ensures that a
-        // compile-time error is generated if $field is accessed through a
-        // Deref impl.
-        let $parent { $field: _, .. };
-
-        // This is UB since we're dealing with dangling references.
-        // We're never dereferencing it, but it's UB nonetheless.
-        // See above for a better version that only works with newer Rust.
-        let non_null = $crate::ptr::NonNull::<$parent>::dangling();
-        #[allow(unused_unsafe)]
-        let base_ptr = unsafe { non_null.as_ref() as *const $parent };
-        #[allow(unused_unsafe)]
         let field_ptr = unsafe { &(*base_ptr).$field as *const _ };
         let offset = (field_ptr as usize) - (base_ptr as usize);
         offset

--- a/src/span_of.rs
+++ b/src/span_of.rs
@@ -163,7 +163,7 @@ mod tests {
 
         assert_eq!(span_of!(Foo, a), 0..4);
         assert_eq!(span_of!(Foo, b), 4..6);
-        assert_eq!(span_of!(Foo, c), 8..8+8);
+        assert_eq!(span_of!(Foo, c), 8..8 + 8);
     }
 
     #[test]
@@ -178,7 +178,7 @@ mod tests {
 
         assert_eq!(span_of!(Foo, a), 0..4);
         assert_eq!(span_of!(Foo, b), 4..6);
-        assert_eq!(span_of!(Foo, c), 6..6+8);
+        assert_eq!(span_of!(Foo, c), 6..6 + 8);
     }
 
     #[test]

--- a/src/span_of.rs
+++ b/src/span_of.rs
@@ -91,30 +91,30 @@ macro_rules! span_of {
          $root as usize + $crate::mem::size_of_val(&(*$root)))
     }};
     (@helper $root:ident, $parent:tt, [] ..= $field:tt) => {{
-        $crate::field_check!($parent, $field);
+        field_check!($parent, $field);
         ($root as usize,
          &(*$root).$field as *const _ as usize + $crate::mem::size_of_val(&(*$root).$field))
     }};
     (@helper $root:ident, $parent:tt, [] .. $field:tt) => {{
-        $crate::field_check!($parent, $field);
+        field_check!($parent, $field);
         ($root as usize, &(*$root).$field as *const _ as usize)
     }};
     // Explicit begin and end for range.
     (@helper $root:ident, $parent:tt, # $begin:tt [] ..= $end:tt) => {{
-        $crate::field_check!($parent, $begin);
-        $crate::field_check!($parent, $end);
+        field_check!($parent, $begin);
+        field_check!($parent, $end);
         (&(*$root).$begin as *const _ as usize,
          &(*$root).$end as *const _ as usize + $crate::mem::size_of_val(&(*$root).$end))
     }};
     (@helper $root:ident, $parent:tt, # $begin:tt [] .. $end:tt) => {{
-        $crate::field_check!($parent, $begin);
-        $crate::field_check!($parent, $end);
+        field_check!($parent, $begin);
+        field_check!($parent, $end);
         (&(*$root).$begin as *const _ as usize,
          &(*$root).$end as *const _ as usize)
     }};
     // No explicit end for range.
     (@helper $root:ident, $parent:tt, # $begin:tt [] ..) => {{
-        $crate::field_check!($parent, $begin);
+        field_check!($parent, $begin);
         (&(*$root).$begin as *const _ as usize,
          $root as usize + $crate::mem::size_of_val(&*$root))
     }};
@@ -124,25 +124,25 @@ macro_rules! span_of {
     }};
     // Just one field.
     (@helper $root:ident, $parent:tt, # $begin:tt []) => {{
-        $crate::field_check!($parent, $begin);
+        field_check!($parent, $begin);
         (&(*$root).$begin as *const _ as usize,
          &(*$root).$begin as *const _ as usize + $crate::mem::size_of_val(&(*$root).$begin))
     }};
     // Parsing.
     (@helper $root:ident, $parent:tt, $(# $begin:tt)+ [] $tt:tt $($rest:tt)*) => {{
-        $crate::span_of!(@helper $root, $parent, $(#$begin)* #$tt [] $($rest)*)
+        span_of!(@helper $root, $parent, $(#$begin)* #$tt [] $($rest)*)
     }};
     (@helper $root:ident, $parent:tt, [] $tt:tt $($rest:tt)*) => {{
-        $crate::span_of!(@helper $root, $parent, #$tt [] $($rest)*)
+        span_of!(@helper $root, $parent, #$tt [] $($rest)*)
     }};
 
     // Entry point.
     ($sty:tt, $($exp:tt)+) => ({
         unsafe {
             // Get a base pointer.
-            $crate::let_base_ptr!(root, $sty);
+            let_base_ptr!(root, $sty);
             let base = root as usize;
-            let (begin, end) = $crate::span_of!(@helper root, $sty, [] $($exp)*);
+            let (begin, end) = span_of!(@helper root, $sty, [] $($exp)*);
             begin-base..end-base
         }
     });

--- a/src/span_of.rs
+++ b/src/span_of.rs
@@ -77,90 +77,44 @@
 ///     assert_eq!(0..42,  span_of!(Blarg, x     ..  y[34]));
 ///     assert_eq!(0..64,  span_of!(Blarg, x     ..= y));
 ///     assert_eq!(58..68, span_of!(Blarg, y[50] ..= z));
-///
-///     const SPAN: std::ops::Range<usize> = span_of!(Blarg, y[50] ..= z);
-///     assert_eq!(58..68, SPAN);
 /// }
 /// ```
 #[macro_export]
-#[cfg(memoffset_constant_expression)]
 macro_rules! span_of {
-    (@helper $root:ident, [] ..=) => (
-        compile_error!("Expected a range, found '..='")
-    );
-    (@helper $root:ident, [] ..) => (
-        compile_error!("Expected a range, found '..'")
-    );
-    (@helper $root:ident, [] ..= $($field:tt)+) => (
-        0..($crate::Transmuter { ptr: &$root.$($field)+ }.int + $crate::size_of(&$root.$($field)+))
-    );
-    (@helper $root:ident, [] .. $($field:tt)+) => (
-        0..$crate::Transmuter { ptr: &$root.$($field)+ }.int
-    );
-    (@helper $root:ident, $(# $begin:tt)+ [] ..= $($end:tt)+) => (
-        $crate::Transmuter { ptr: &$root.$($begin)+ }.int..($crate::Transmuter { ptr: &$root.$($end)+ }.int + $crate::size_of(&$root.$($end)+))
-    );
-    (@helper $root:ident, $(# $begin:tt)+ [] .. $($end:tt)+) => (
-        $crate::Transmuter { ptr: &$root.$($begin)+ }.int..$crate::Transmuter { ptr: &$root.$($end)+ }.int
-    );
-    (@helper $root:ident, $(# $begin:tt)+ [] ..) => (
-        $crate::Transmuter { ptr: &$root.$($begin)+ }.int..$crate::size_of($root)
-    );
-    (@helper $root:ident, $(# $begin:tt)+ [] ..=) => {
-        compile_error!(
-            "Found inclusive range to the end of a struct. Did you mean '..' instead of '..='?")
-    };
-    (@helper $root:ident, $(# $begin:tt)+ [] ) => ({
-        let start = $crate::Transmuter { ptr: &$root.$($begin)+ }.int;
-        start..(start + $crate::size_of(&$root.$($begin)+))
-    });
-    (@helper $root:ident, $(# $begin:tt)+ [] $tt:tt $($rest:tt)*) => {
-        span_of!(@helper $root, $(#$begin)* #$tt [] $($rest)*)
-    };
-    (@helper $root:ident, [] $tt:tt $($rest:tt)*) => {
-        span_of!(@helper $root, #$tt [] $($rest)*)
-    };
-
-    ($parent:ty, $($exp:tt)+) => (unsafe {
-        let root: &'static $parent = $crate::Transmuter::<$parent> { int: 0 }.ptr;
-        span_of!(@helper root, [] $($exp)*)
-    });
-}
-
-#[macro_export]
-#[cfg(not(memoffset_constant_expression))]
-macro_rules! span_of {
-    (@helper $root:ident, [] ..=) => {
+    (@helper  $root:ident, [] ..=) => {
         compile_error!("Expected a range, found '..='")
     };
     (@helper $root:ident, [] ..) => {
         compile_error!("Expected a range, found '..'")
     };
+    // Lots of UB due to taking references to uninitialized fields! But that can currently
+    // not be avoided.
     (@helper $root:ident, [] ..= $($field:tt)+) => {
-        (&$root as *const _ as usize,
-         &$root.$($field)* as *const _ as usize + $crate::mem::size_of_val(&$root.$($field)*))
+        ($root as usize,
+         &(*$root).$($field)* as *const _ as usize + $crate::mem::size_of_val(&(*$root).$($field)*))
     };
     (@helper $root:ident, [] .. $($field:tt)+) => {
-        (&$root as *const _ as usize, &$root.$($field)* as *const _ as usize)
+        ($root as usize, &(*$root).$($field)* as *const _ as usize)
     };
     (@helper $root:ident, $(# $begin:tt)+ [] ..= $($end:tt)+) => {
-        (&$root.$($begin)* as *const _ as usize,
-         &$root.$($end)* as *const _ as usize + $crate::mem::size_of_val(&$root.$($end)*))
+        (&(*$root).$($begin)* as *const _ as usize,
+         &(*$root).$($end)* as *const _ as usize + $crate::mem::size_of_val(&(*$root).$($end)*))
     };
     (@helper $root:ident, $(# $begin:tt)+ [] .. $($end:tt)+) => {
-        (&$root.$($begin)* as *const _ as usize, &$root.$($end)* as *const _ as usize)
+        (&(*$root).$($begin)* as *const _ as usize,
+         &(*$root).$($end)* as *const _ as usize)
     };
     (@helper $root:ident, $(# $begin:tt)+ [] ..) => {
-        (&$root.$($begin)* as *const _ as usize,
-         &$root as *const _ as usize + $crate::mem::size_of_val(&$root))
+        (&(*$root).$($begin)* as *const _ as usize,
+         $root as usize + $crate::mem::size_of_val(&*$root))
     };
     (@helper $root:ident, $(# $begin:tt)+ [] ..=) => {
         compile_error!(
             "Found inclusive range to the end of a struct. Did you mean '..' instead of '..='?")
     };
     (@helper $root:ident, $(# $begin:tt)+ []) => {
-        (&$root.$($begin)* as *const _ as usize,
-         &$root.$($begin)* as *const _ as usize + $crate::mem::size_of_val(&$root.$($begin)*))
+        (&(*$root).$($begin)* as *const _ as usize,
+         &(*$root).$($begin)* as *const _ as usize + $crate::mem::size_of_val(&(*$root).$($begin)*))
     };
     (@helper $root:ident, $(# $begin:tt)+ [] $tt:tt $($rest:tt)*) => {
         span_of!(@helper $root, $(#$begin)* #$tt [] $($rest)*)
@@ -169,10 +123,11 @@ macro_rules! span_of {
         span_of!(@helper $root, #$tt [] $($rest)*)
     };
 
-    ($sty:ty, $($exp:tt)+) => ({
+    ($sty:tt, $($exp:tt)+) => ({
         unsafe {
-            let root: $sty = $crate::mem::uninitialized();
-            let base = &root as *const _ as usize;
+            // Get a base pointer.
+            $crate::let_base_ptr!(root, $sty);
+            let base = root as usize;
             let (begin, end) = span_of!(@helper root, [] $($exp)*);
             begin-base..end-base
         }

--- a/src/span_of.rs
+++ b/src/span_of.rs
@@ -148,33 +148,48 @@ macro_rules! span_of {
 mod tests {
     use core::mem;
 
-    #[repr(C, packed)]
-    struct Foo {
-        a: u32,
-        b: [u8; 4],
-        c: i64,
+    #[test]
+    fn span_simple() {
+        #[repr(C)]
+        struct Foo {
+            a: u32,
+            b: [u8; 2],
+            c: i64,
+        }
+
+        assert_eq!(span_of!(Foo, a), 0..4);
+        assert_eq!(span_of!(Foo, b), 4..6);
+        assert_eq!(span_of!(Foo, c), 8..8+8);
     }
 
     #[test]
-    fn span_simple() {
+    #[cfg(not(miri))] // this creates unaligned references
+    fn span_simple_packed() {
+        #[repr(C, packed)]
+        struct Foo {
+            a: u32,
+            b: [u8; 2],
+            c: i64,
+        }
+
         assert_eq!(span_of!(Foo, a), 0..4);
-        assert_eq!(span_of!(Foo, b), 4..8);
-        assert_eq!(span_of!(Foo, c), 8..16);
+        assert_eq!(span_of!(Foo, b), 4..6);
+        assert_eq!(span_of!(Foo, c), 6..6+8);
     }
 
     #[test]
     fn span_forms() {
-        #[repr(C, packed)]
+        #[repr(C)]
         struct Florp {
             a: u32,
         }
 
-        #[repr(C, packed)]
+        #[repr(C)]
         struct Blarg {
             x: u64,
             y: [u8; 56],
             z: Florp,
-            egg: [[u8; 4]; 4],
+            egg: [[u8; 4]; 5],
         }
 
         // Love me some brute force

--- a/src/span_of.rs
+++ b/src/span_of.rs
@@ -22,11 +22,10 @@
 ///
 /// This macro provides 2 forms of differing functionalities.
 ///
-/// The first form is identical to the appearance of the `offset_of!` macro,
-/// and just like `offset_of!`, it has no limit on the depth of fields / subscripts used.
+/// The first form is identical to the appearance of the `offset_of!` macro.
 ///
 /// ```ignore
-/// span_of!(Struct, member[index].field)
+/// span_of!(Struct, member)
 /// ```
 ///
 /// The second form of `span_of!` returns a sub-slice which starts at one field, and ends at another.
@@ -44,11 +43,9 @@
 /// ```
 ///
 /// *Note*:
-/// This macro uses recursion in order to resolve the range expressions, so there is a limit to the complexity of the expression.
+/// This macro uses recursion in order to resolve the range expressions, so there is a limit to
+/// the complexity of the expression.
 /// In order to raise the limit, the compiler's recursion limit should be lifted.
-///
-/// *Note*:
-/// This macro may not make much sense when used on structs that are not `#[repr(C, packed)]`
 ///
 /// ## Examples
 /// ```
@@ -70,13 +67,8 @@
 ///
 /// fn main() {
 ///     assert_eq!(0..8,   span_of!(Blarg, x));
-///     assert_eq!(64..68, span_of!(Blarg, z.a));
-///     assert_eq!(79..80, span_of!(Blarg, egg[2][3]));
-///
-///     assert_eq!(8..64,  span_of!(Blarg, y[0]  ..  z));
-///     assert_eq!(0..42,  span_of!(Blarg, x     ..  y[34]));
-///     assert_eq!(0..64,  span_of!(Blarg, x     ..= y));
-///     assert_eq!(58..68, span_of!(Blarg, y[50] ..= z));
+///     assert_eq!(8..84,  span_of!(Blarg, y ..));
+///     assert_eq!(0..64,  span_of!(Blarg, x ..= y));
 /// }
 /// ```
 #[macro_export]
@@ -89,33 +81,50 @@ macro_rules! span_of {
     };
     // Lots of UB due to taking references to uninitialized fields! But that can currently
     // not be avoided.
-    (@helper $root:ident, $parent:tt, [] ..= $($field:tt)*) => {{
+    // No explicit begin for range.
+    (@helper $root:ident, $parent:tt, [] ..) => {{
         ($root as usize,
-         &(*$root).$($field)* as *const _ as usize + $crate::mem::size_of_val(&(*$root).$($field)*))
+         $root as usize + $crate::mem::size_of_val(&(*$root)))
     }};
-    (@helper $root:ident, $parent:tt, [] .. $($field:tt)+) => {{
-        ($root as usize, &(*$root).$($field)* as *const _ as usize)
+    (@helper $root:ident, $parent:tt, [] ..= $field:tt) => {{
+        field_check!($parent, $field);
+        ($root as usize,
+         &(*$root).$field as *const _ as usize + $crate::mem::size_of_val(&(*$root).$field))
     }};
-    (@helper $root:ident, $parent:tt, $(# $begin:tt)+ [] ..= $($end:tt)+) => {{
-        (&(*$root).$($begin)* as *const _ as usize,
-         &(*$root).$($end)* as *const _ as usize + $crate::mem::size_of_val(&(*$root).$($end)*))
+    (@helper $root:ident, $parent:tt, [] .. $field:tt) => {{
+        field_check!($parent, $field);
+        ($root as usize, &(*$root).$field as *const _ as usize)
     }};
-    (@helper $root:ident, $parent:tt, $(# $begin:tt)+ [] .. $($end:tt)+) => {{
-        (&(*$root).$($begin)* as *const _ as usize,
-         &(*$root).$($end)* as *const _ as usize)
+    // Explicit begin and end for range.
+    (@helper $root:ident, $parent:tt, # $begin:tt [] ..= $end:tt) => {{
+        field_check!($parent, $begin);
+        field_check!($parent, $end);
+        (&(*$root).$begin as *const _ as usize,
+         &(*$root).$end as *const _ as usize + $crate::mem::size_of_val(&(*$root).$end))
     }};
-    (@helper $root:ident, $parent:tt, $(# $begin:tt)+ [] ..) => {{
-        (&(*$root).$($begin)* as *const _ as usize,
+    (@helper $root:ident, $parent:tt, # $begin:tt [] .. $end:tt) => {{
+        field_check!($parent, $begin);
+        field_check!($parent, $end);
+        (&(*$root).$begin as *const _ as usize,
+         &(*$root).$end as *const _ as usize)
+    }};
+    // No explicit end for range.
+    (@helper $root:ident, $parent:tt, # $begin:tt [] ..) => {{
+        field_check!($parent, $begin);
+        (&(*$root).$begin as *const _ as usize,
          $root as usize + $crate::mem::size_of_val(&*$root))
     }};
-    (@helper $root:ident, $parent:tt, $(# $begin:tt)+ [] ..=) => {{
+    (@helper $root:ident, $parent:tt, # $begin:tt [] ..=) => {{
         compile_error!(
             "Found inclusive range to the end of a struct. Did you mean '..' instead of '..='?")
     }};
-    (@helper $root:ident, $parent:tt, $(# $begin:tt)+ []) => {{
-        (&(*$root).$($begin)* as *const _ as usize,
-         &(*$root).$($begin)* as *const _ as usize + $crate::mem::size_of_val(&(*$root).$($begin)*))
+    // Just one field.
+    (@helper $root:ident, $parent:tt, # $begin:tt []) => {{
+        field_check!($parent, $begin);
+        (&(*$root).$begin as *const _ as usize,
+         &(*$root).$begin as *const _ as usize + $crate::mem::size_of_val(&(*$root).$begin))
     }};
+    // Parsing.
     (@helper $root:ident, $parent:tt, $(# $begin:tt)+ [] $tt:tt $($rest:tt)*) => {{
         span_of!(@helper $root, $parent, $(#$begin)* #$tt [] $($rest)*)
     }};
@@ -123,6 +132,7 @@ macro_rules! span_of {
         span_of!(@helper $root, $parent, #$tt [] $($rest)*)
     }};
 
+    // Entry point.
     ($sty:tt, $($exp:tt)+) => ({
         unsafe {
             // Get a base pointer.
@@ -153,11 +163,6 @@ mod tests {
     }
 
     #[test]
-    fn span_index() {
-        assert_eq!(span_of!(Foo, b[1]), 5..6);
-    }
-
-    #[test]
     fn span_forms() {
         #[repr(C, packed)]
         struct Florp {
@@ -174,13 +179,11 @@ mod tests {
 
         // Love me some brute force
         assert_eq!(0..8, span_of!(Blarg, x));
-        assert_eq!(64..68, span_of!(Blarg, z.a));
-        assert_eq!(79..80, span_of!(Blarg, egg[2][3]));
+        assert_eq!(64..68, span_of!(Blarg, z));
+        assert_eq!(68..mem::size_of::<Blarg>(), span_of!(Blarg, egg));
 
-        assert_eq!(8..64, span_of!(Blarg, y[0]..z));
-        assert_eq!(0..42, span_of!(Blarg, x..y[34]));
+        assert_eq!(8..64, span_of!(Blarg, y..z));
         assert_eq!(0..64, span_of!(Blarg, x..=y));
-        assert_eq!(58..68, span_of!(Blarg, y[50]..=z));
     }
 
     #[test]
@@ -202,18 +205,11 @@ mod tests {
         assert_eq!(span_of!(Test, ..=x), 0..8);
         assert_eq!(span_of!(Test, ..y), 0..8);
         assert_eq!(span_of!(Test, ..=y), 0..64);
-        assert_eq!(span_of!(Test, ..y[0]), 0..8);
-        assert_eq!(span_of!(Test, ..=y[0]), 0..9);
         assert_eq!(span_of!(Test, ..z), 0..64);
         assert_eq!(span_of!(Test, ..=z), 0..68);
-        assert_eq!(span_of!(Test, ..z.foo), 0..64);
-        assert_eq!(span_of!(Test, ..=z.foo), 0..68);
         assert_eq!(span_of!(Test, ..egg), 0..68);
         assert_eq!(span_of!(Test, ..=egg), 0..84);
-        assert_eq!(span_of!(Test, ..egg[0]), 0..68);
-        assert_eq!(span_of!(Test, ..=egg[0]), 0..72);
-        assert_eq!(span_of!(Test, ..egg[0][0]), 0..68);
-        assert_eq!(span_of!(Test, ..=egg[0][0]), 0..69);
+        assert_eq!(span_of!(Test, ..), 0..mem::size_of::<Test>());
         assert_eq!(
             span_of!(Test, x..),
             offset_of!(Test, x)..mem::size_of::<Test>()
@@ -238,10 +234,6 @@ mod tests {
         assert_eq!(
             span_of!(Test, x..=y),
             offset_of!(Test, x)..offset_of!(Test, y) + mem::size_of::<[u8; 56]>()
-        );
-        assert_eq!(
-            span_of!(Test, x..=y[4]),
-            offset_of!(Test, x)..offset_of!(Test, y) + mem::size_of::<[u8; 5]>()
         );
     }
 }


### PR DESCRIPTION
Fix span_of in two ways: no more `mem::uninitialized`, and protect against deref coercions. This unfortunately has to drop support for nested fields and arrays, just like for `offset_of`.

Also share some code with offset_of, and update documentation.