### PR TITLE
Fix README and lower minimum Rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: rust
 rust:
-  - 1.25.0  # Oldest supported
+  - 1.25.0  # Oldest supported (to make doc-comment not ICE)
   - 1.36.0  # Oldest supported with MaybeUninit
   - stable
   - beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
     rust: 1.33.0  # `stable`: Locking down for consistent behavior
     script:
     - cargo check --tests
-  allow_failures:
-    - rust: nightly
   fast_finish: true
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   - env: RUSTFMT
     rust: 1.36.0
     install:
-    - rustup component add rustfmt-preview
+    - rustup component add rustfmt
     script:
     - cargo fmt -- --check
   - env: RUSTFLAGS="-D warnings"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rust:
 matrix:
   include:
   - env: RUSTFMT
-    rust: 1.25.0
     rust: 1.36.0
     install:
     - rustup component add rustfmt-preview

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: rust
 rust:
-  - 1.25.0  # Oldest supported (to make doc-comment not ICE)
+  - 1.20.0  # Oldest supported
   - 1.36.0  # Oldest supported with MaybeUninit
   - stable
   - beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["no-std"]
 [build-dependencies]
 rustc_version = "0.2.3"
 
-[dev-dependencies]
+[dependencies]
 doc-comment = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["no-std"]
 [build-dependencies]
 rustc_version = "0.2.3"
 
-[dependencies]
+[dev-dependencies]
 doc-comment = "0.3"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the following dependency to your `Cargo.toml`:
 memoffset = "0.5"
 ```
 
-These versions will compile fine with rustc versions greater or equal to 1.25.
+These versions will compile fine with rustc versions greater or equal to 1.20.
 
 Add the following lines at the top of your `main.rs` or `lib.rs` files.
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,12 @@ struct Foo {
 
 fn main() {
 	assert_eq!(offset_of!(Foo, b), 4);
-	assert_eq!(offset_of!(Foo, c[3]), 11);
+	assert_eq!(offset_of!(Foo, d), 4+4+5);
 
-	assert_eq!(span_of!(Foo, a),          0..4);
-	assert_eq!(span_of!(Foo, a ..  c),    0..8);
-	assert_eq!(span_of!(Foo, a ..  c[1]), 0..9);
-	assert_eq!(span_of!(Foo, a ..= c[1]), 0..10);
-	assert_eq!(span_of!(Foo, ..= d),      0..17);
-	assert_eq!(span_of!(Foo, b ..),       4..17);
+	assert_eq!(span_of!(Foo, a),        0..4);
+	assert_eq!(span_of!(Foo, a ..  c),  0..8);
+	assert_eq!(span_of!(Foo, a ..= c),  0..13);
+	assert_eq!(span_of!(Foo, ..= d),    0..17);
+	assert_eq!(span_of!(Foo, b ..),     4..17);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -15,15 +15,10 @@ Add the following dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-memoffset = "0.3"
+memoffset = "0.5"
 ```
 
-Versions ">= 0.3" can be used in a constant expression context (though not in a `const fn`),
-but require a rust version greater than or equal to 1.33.
-These versions will compile fine with rustc versions greater or equal to 1.19, but will
-lack support for constant expression.
-
-If you wish to use an older rustc version, lock your dependency to "0.2"
+These versions will compile fine with rustc versions greater or equal to 1.25.
 
 Add the following lines at the top of your `main.rs` or `lib.rs` files.
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate rustc_version;
-use rustc_version::{version, version_meta, Version, Channel};
+use rustc_version::{version, version_meta, Channel, Version};
 
 fn main() {
     // Assert we haven't travelled back in time

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate rustc_version;
-use rustc_version::{version, Version};
+use rustc_version::{version, version_meta, Version, Channel};
 
 fn main() {
     // Assert we haven't travelled back in time
@@ -8,5 +8,10 @@ fn main() {
     // Check for a minimum version
     if version().unwrap() >= Version::parse("1.36.0").unwrap() {
         println!("cargo:rustc-cfg=memoffset_maybe_uninit");
+    }
+
+    // Check for nightly.
+    if let Channel::Nightly = version_meta().unwrap().channel {
+        println!("cargo:rustc-cfg=memoffset_nightly");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,11 +62,8 @@
 
 #![no_std]
 
-#[cfg(test)]
 #[macro_use]
 extern crate doc_comment;
-
-#[cfg(test)]
 doctest!("../README.md");
 
 // This `use` statement enables the macros to use `$crate::mem`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,10 +61,7 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(
-    memoffset_nightly,
-    feature(cfg_doctest)
-)]
+#![cfg_attr(memoffset_nightly, feature(cfg_doctest))]
 
 #[macro_use]
 #[cfg(memoffset_nightly)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,17 @@
 //! ```
 
 #![no_std]
+#![cfg_attr(
+    memoffset_nightly,
+    feature(cfg_doctest)
+)]
 
 #[macro_use]
+#[cfg(memoffset_nightly)]
+#[cfg(doctest)]
 extern crate doc_comment;
+#[cfg(memoffset_nightly)]
+#[cfg(doctest)]
 doctest!("../README.md");
 
 // This `use` statement enables the macros to use `$crate::mem`.

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -39,10 +39,9 @@ macro_rules! _memoffset__let_base_ptr {
 #[doc(hidden)]
 macro_rules! _memoffset__let_base_ptr {
     ($name:ident, $type:tt) => {
-        // No UB right here, but we will later offset into a field
-        // of this pointer, and that is UB when the pointer is dangling.
-        let non_null = $crate::ptr::NonNull::<$type>::dangling();
-        let $name = non_null.as_ptr() as *const $type;
+        // No UB right here, but we will later dereference this pointer to
+        // offset into a field, and that is UB when the pointer is dangling.
+        let $name = $crate::mem::align_of::<$type>() as *const $type;
     };
 }
 


### PR DESCRIPTION
Includes https://github.com/Gilnaa/memoffset/pull/8.

I am also trying to lower the minimal Rust version to 1.20, as I cannot figure out why it was raised to 1.25.