### PR TITLE
explain why we do not have deref coercion problems

### DIFF
--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -85,6 +85,8 @@ macro_rules! offset_of {
         _memoffset__let_base_ptr!(base_ptr, $parent);
         // Get the field address. This is UB because we are creating a reference to
         // the uninitialized field.
+        // Crucially, we know that this will not trigger a deref coercion because
+        // of the `field_check!` we did above.
         #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
         let field_ptr = unsafe { &(*base_ptr).$field as *const _ };
         let offset = (field_ptr as usize) - (base_ptr as usize);


### PR DESCRIPTION
This is an important aspect of any `offset_of` macro, so it is worth calling out explicitly here.