### PR TITLE
Add container_of

### DIFF
--- a/src/container_of.rs
+++ b/src/container_of.rs
@@ -1,5 +1,3 @@
-
-
 /// Calculates the address of a containing struct from a pointer to one of its
 /// fields.
 ///
@@ -30,7 +28,7 @@
 #[macro_export(local_inner_macros)]
 macro_rules! container_of {
     ($ptr:expr, $container:path, $field:tt) => {
-        ($ptr as *const _ as *const u8).sub(offset_of!($container, $field))
+        ($ptr as *const _ as *const u8).offset(-(offset_of!($container, $field) as isize))
             as *mut $container
     };
 }

--- a/src/container_of.rs
+++ b/src/container_of.rs
@@ -100,14 +100,14 @@ mod tests {
 
     #[test]
     fn non_copy() {
-        use core::cell::Cell;
+        use core::cell::RefCell;
 
         #[repr(C)]
         struct Foo {
-            a: Cell<u8>,
+            a: RefCell<u8>,
         }
 
-        let x = Foo { a: Cell::new(0) };
+        let x = Foo { a: RefCell::new(0) };
         unsafe {
             assert_eq!(container_of!(&x.a, Foo, a), &x as *const _);
         }

--- a/src/container_of.rs
+++ b/src/container_of.rs
@@ -32,7 +32,7 @@ macro_rules! container_of {
         if false {
             // Ensure that the pointer has the correct type.
             let $container { $field: _f, .. };
-            _f = *ptr;
+            _f = $crate::ptr::read(ptr);
         }
 
         // We don't use .sub because we need to support older Rust versions.
@@ -95,6 +95,21 @@ mod tests {
         unsafe {
             assert_eq!(container_of!(&x.0, Tup, 0), &x as *const _);
             assert_eq!(container_of!(&x.1, Tup, 1), &x as *const _);
+        }
+    }
+
+    #[test]
+    fn non_copy() {
+        use core::cell::Cell;
+
+        #[repr(C)]
+        struct Foo {
+            a: Cell<u8>,
+        }
+
+        let x = Foo { a: Cell::new(0) };
+        unsafe {
+            assert_eq!(container_of!(&x.a, Foo, a), &x as *const _);
         }
     }
 }

--- a/src/container_of.rs
+++ b/src/container_of.rs
@@ -1,0 +1,36 @@
+
+
+/// Calculates the address of a containing struct from a pointer to one of its
+/// fields.
+///
+/// # Safety
+///
+/// This is unsafe because it assumes that the given expression is a valid
+/// pointer to the specified field of some container type.
+///
+/// ## Examples
+/// ```
+/// #[macro_use]
+/// extern crate memoffset;
+///
+/// #[repr(C, packed)]
+/// struct Foo {
+///     a: u32,
+///     b: u64,
+///     c: [u8; 5]
+/// }
+///
+/// fn main() {
+///     let container = Foo { a: 1, b: 2, c: [3; 5] };
+///     let field = &container.b;
+///     let container2: *const Foo = unsafe { container_of!(field, Foo, b) };
+///     assert_eq!(&container as *const Foo, container2);
+/// }
+/// ```
+#[macro_export(local_inner_macros)]
+macro_rules! container_of {
+    ($ptr:expr, $container:path, $field:tt) => {
+        ($ptr as *const _ as *const u8).sub(offset_of!($container, $field))
+            as *mut $container
+    };
+}

--- a/src/container_of.rs
+++ b/src/container_of.rs
@@ -27,8 +27,16 @@
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! container_of {
-    ($ptr:expr, $container:path, $field:tt) => {
-        ($ptr as *const _ as *const u8).offset(-(offset_of!($container, $field) as isize))
+    ($ptr:expr, $container:path, $field:tt) => {{
+        let ptr = $ptr as *const _;
+        if false {
+            // Ensure that the pointer has the correct type.
+            let $container { $field: f, .. };
+            f = *ptr;
+        }
+
+        // We don't use .sub because we need to support older Rust versions.
+        (ptr as *const u8).offset((offset_of!($container, $field) as isize).wrapping_neg())
             as *mut $container
-    };
+    }};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,3 +83,5 @@ pub use core::ptr;
 mod offset_of;
 #[macro_use]
 mod span_of;
+#[macro_use]
+mod container_of;

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -138,7 +138,9 @@ mod tests {
     fn path() {
         mod sub {
             #[repr(C)]
-            pub struct Foo { pub x: u32 }
+            pub struct Foo {
+                pub x: u32,
+            }
         }
 
         assert_eq!(offset_of!(sub::Foo, x), 0);

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -24,7 +24,7 @@
 #[macro_export]
 #[doc(hidden)]
 macro_rules! _memoffset__let_base_ptr {
-    ($name:ident, $type:tt) => {
+    ($name:ident, $type:path) => {
         // No UB here, and the pointer does not dangle, either.
         // But we have to make sure that `uninit` lives long enough,
         // so it has to be in the same scope as `$name`. That's why
@@ -38,7 +38,7 @@ macro_rules! _memoffset__let_base_ptr {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! _memoffset__let_base_ptr {
-    ($name:ident, $type:tt) => {
+    ($name:ident, $type:path) => {
         // No UB right here, but we will later dereference this pointer to
         // offset into a field, and that is UB when the pointer is dangling.
         let $name = $crate::mem::align_of::<$type>() as *const $type;
@@ -49,7 +49,7 @@ macro_rules! _memoffset__let_base_ptr {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! _memoffset__field_check {
-    ($type:tt, $field:tt) => {
+    ($type:path, $field:tt) => {
         // Make sure the field actually exists. This line ensures that a
         // compile-time error is generated if $field is accessed through a
         // Deref impl.
@@ -78,7 +78,7 @@ macro_rules! _memoffset__field_check {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! offset_of {
-    ($parent:tt, $field:tt) => {{
+    ($parent:path, $field:tt) => {{
         _memoffset__field_check!($parent, $field);
 
         // Get a base pointer.
@@ -132,5 +132,15 @@ mod tests {
 
         assert_eq!(offset_of!(Tup, 0), 0);
         assert_eq!(offset_of!(Tup, 1), 4);
+    }
+
+    #[test]
+    fn path() {
+        mod sub {
+            #[repr(C)]
+            pub struct Foo { pub x: u32 }
+        }
+
+        assert_eq!(offset_of!(sub::Foo, x), 0);
     }
 }

--- a/src/span_of.rs
+++ b/src/span_of.rs
@@ -96,58 +96,58 @@ macro_rules! span_of {
     // Lots of UB due to taking references to uninitialized fields! But that can currently
     // not be avoided.
     // No explicit begin for range.
-    (@helper $root:ident, $parent:tt, [] ..) => {{
+    (@helper $root:ident, $parent:path, [] ..) => {{
         ($root as usize,
          $root as usize + $crate::mem::size_of_val(&(*$root)))
     }};
-    (@helper $root:ident, $parent:tt, [] ..= $field:tt) => {{
+    (@helper $root:ident, $parent:path, [] ..= $field:tt) => {{
         _memoffset__field_check!($parent, $field);
         ($root as usize,
          &(*$root).$field as *const _ as usize + $crate::mem::size_of_val(&(*$root).$field))
     }};
-    (@helper $root:ident, $parent:tt, [] .. $field:tt) => {{
+    (@helper $root:ident, $parent:path, [] .. $field:tt) => {{
         _memoffset__field_check!($parent, $field);
         ($root as usize, &(*$root).$field as *const _ as usize)
     }};
     // Explicit begin and end for range.
-    (@helper $root:ident, $parent:tt, # $begin:tt [] ..= $end:tt) => {{
+    (@helper $root:ident, $parent:path, # $begin:tt [] ..= $end:tt) => {{
         _memoffset__field_check!($parent, $begin);
         _memoffset__field_check!($parent, $end);
         (&(*$root).$begin as *const _ as usize,
          &(*$root).$end as *const _ as usize + $crate::mem::size_of_val(&(*$root).$end))
     }};
-    (@helper $root:ident, $parent:tt, # $begin:tt [] .. $end:tt) => {{
+    (@helper $root:ident, $parent:path, # $begin:tt [] .. $end:tt) => {{
         _memoffset__field_check!($parent, $begin);
         _memoffset__field_check!($parent, $end);
         (&(*$root).$begin as *const _ as usize,
          &(*$root).$end as *const _ as usize)
     }};
     // No explicit end for range.
-    (@helper $root:ident, $parent:tt, # $begin:tt [] ..) => {{
+    (@helper $root:ident, $parent:path, # $begin:tt [] ..) => {{
         _memoffset__field_check!($parent, $begin);
         (&(*$root).$begin as *const _ as usize,
          $root as usize + $crate::mem::size_of_val(&*$root))
     }};
-    (@helper $root:ident, $parent:tt, # $begin:tt [] ..=) => {{
+    (@helper $root:ident, $parent:path, # $begin:tt [] ..=) => {{
         _memoffset__compile_error!(
             "Found inclusive range to the end of a struct. Did you mean '..' instead of '..='?")
     }};
     // Just one field.
-    (@helper $root:ident, $parent:tt, # $begin:tt []) => {{
+    (@helper $root:ident, $parent:path, # $begin:tt []) => {{
         _memoffset__field_check!($parent, $begin);
         (&(*$root).$begin as *const _ as usize,
          &(*$root).$begin as *const _ as usize + $crate::mem::size_of_val(&(*$root).$begin))
     }};
     // Parsing.
-    (@helper $root:ident, $parent:tt, $(# $begin:tt)+ [] $tt:tt $($rest:tt)*) => {{
+    (@helper $root:ident, $parent:path, $(# $begin:tt)+ [] $tt:tt $($rest:tt)*) => {{
         span_of!(@helper $root, $parent, $(#$begin)* #$tt [] $($rest)*)
     }};
-    (@helper $root:ident, $parent:tt, [] $tt:tt $($rest:tt)*) => {{
+    (@helper $root:ident, $parent:path, [] $tt:tt $($rest:tt)*) => {{
         span_of!(@helper $root, $parent, #$tt [] $($rest)*)
     }};
 
     // Entry point.
-    ($sty:tt, $($exp:tt)+) => ({
+    ($sty:path, $($exp:tt)+) => ({
         unsafe {
             // Get a base pointer.
             _memoffset__let_base_ptr!(root, $sty);


### PR DESCRIPTION
This adds `container_of`, an unsafe macro which allows obtaining a raw pointer to the containing struct from a pointer to one of its fields.

I also fixed the other macros to take in a `path` instead of a `tt` for the struct name, which allows complex path such as `my_mod::Foo`.