### PR TITLE
Fixed build for old nightlies where doctests were not present.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,18 @@
 extern crate rustc_version;
-use rustc_version::{version, version_meta, Channel, Version};
+use rustc_version::{version, Version};
 
 fn main() {
+    let version = version().unwrap();
+
     // Assert we haven't travelled back in time
-    assert!(version().unwrap().major >= 1);
+    assert!(version.major >= 1);
 
     // Check for a minimum version
-    if version().unwrap() >= Version::parse("1.36.0").unwrap() {
+    if version >= Version::from((1, 36, 0)) {
         println!("cargo:rustc-cfg=memoffset_maybe_uninit");
     }
 
-    // Check for nightly.
-    if let Channel::Nightly = version_meta().unwrap().channel {
-        println!("cargo:rustc-cfg=memoffset_nightly");
+    if version >= Version::from((1, 40, 0)) {
+        println!("cargo:rustc-cfg=memoffset_doctests");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,13 +57,12 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(memoffset_nightly, feature(cfg_doctest))]
 
 #[macro_use]
-#[cfg(memoffset_nightly)]
+#[cfg(memoffset_doctests)]
 #[cfg(doctest)]
 extern crate doc_comment;
-#[cfg(memoffset_nightly)]
+#[cfg(memoffset_doctests)]
 #[cfg(doctest)]
 doctest!("../README.md");
 


### PR DESCRIPTION
Tested with nightly-2017-09-01 which was just after 1.20 was released.

The 1.40 version comparison currently **doesn't work**, since the nightly 1.40 compiler equates lower than `Version::from((1, 40, 0))`. This shouldn't be a problem once 1.41 nightly compilers are available. 