### PR TITLE
add support for using raw_ref macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     script:  # `--lib` added to prevent doctests from being compiled.
              # This is due to `unstable_const` requiring extra `feature(...)` directives
              # which the doctests do not have.
-      - cargo test --verbose --features unstable_const --lib
+      - cargo test --verbose --all-features --lib
 
   - env: RUSTFMT
     rust: 1.36.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ cache:
   cargo: true
 matrix:
   include:
+  - name: miri
+    rust: nightly
+    os: linux
+    script:
+      - sh ci/miri.sh
+
   - rust: 1.19.0  # Oldest supported (first version with numeric fields in struct patterns)
   - rust: 1.31.0  # Oldest supported with allow(clippy)
   - rust: 1.36.0  # Oldest supported with MaybeUninit
@@ -11,13 +17,7 @@ matrix:
   - rust: beta
   - rust: nightly
 
-  - env: MIRI
-    rust: nightly
-    os: linux
-    script:
-      - sh ci/miri.sh
-
-  - env: CONST_OFFSET
+  - name: all-features
     rust: nightly
     os: linux
     script:  # `--lib` added to prevent doctests from being compiled.
@@ -25,14 +25,15 @@ matrix:
              # which the doctests do not have.
       - cargo test --verbose --all-features --lib
 
-  - env: RUSTFMT
+  - name: rustfmt
     rust: 1.36.0
     install:
     - rustup component add rustfmt
     script:
     - cargo fmt -- --check
 
-  - env: RUSTFLAGS="-D warnings"
+  - name: deny-warnings
+    env: RUSTFLAGS="-D warnings"
     rust: 1.33.0  # `stable`: Locking down for consistent behavior
     script:
     - cargo check --tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ doc-comment = "0.3"
 [features]
 default = []
 unstable_const = []
+unstable_raw = []

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ fn main() {
 }
 ```
 
-## Usage in constants ##
+## Feature flags ##
+
+### Usage in constants ###
 `memoffset` has **experimental** support for compile-time `offset_of!` on a nightly compiler.
 
 In order to use it, you must enable the `unstable_const` crate feature and several compiler features.
@@ -79,3 +81,8 @@ struct Foo {
 
 let foo = [0; offset_of!(Foo, b)] 
 ```
+
+### Raw references ###
+Recent nightlies support [a way to create raw pointers](https://github.com/rust-lang/rust/issues/73394) that avoids creating intermediate safe references.
+`memoffset` can make use of that feature to avoid what is technically Undefined Behavior.
+Use the `unstable_raw` feature to enable this.

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -8,3 +8,4 @@ rustup component add miri
 cargo miri setup
 
 cargo miri test
+cargo miri test --all-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,10 @@
         const_raw_ptr_deref
     )
 )]
+#![cfg_attr(
+    feature = "unstable_raw",
+    feature(raw_ref_macros)
+)]
 
 #[macro_use]
 #[cfg(doctests)]
@@ -79,7 +83,6 @@ doctest!("../README.md");
 // Doing this enables this crate to function under both std and no-std crates.
 #[doc(hidden)]
 pub use core::mem;
-
 #[doc(hidden)]
 pub use core::ptr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,10 +66,7 @@
         const_raw_ptr_deref
     )
 )]
-#![cfg_attr(
-    feature = "unstable_raw",
-    feature(raw_ref_macros)
-)]
+#![cfg_attr(feature = "unstable_raw", feature(raw_ref_macros))]
 
 #[macro_use]
 #[cfg(doctests)]

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -63,6 +63,29 @@ macro_rules! _memoffset__field_check {
 ///
 /// The `base` pointer *must not* be dangling, but it *may* point to
 /// uninitialized memory.
+#[cfg(feature = "unstable_raw")] // Correct variant that uses `raw_const!`.
+#[macro_export(local_inner_macros)]
+macro_rules! raw_field {
+    ($base:expr, $parent:path, $field:tt) => {{
+        _memoffset__field_check!($parent, $field);
+        let base_ptr: *const $parent = $base;
+
+        // Get the field address without creating a reference.
+        // Crucially, we know that this will not trigger a deref coercion because
+        // of the `field_check!` we did above.
+        #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
+        unsafe {
+            $crate::ptr::raw_const!((*base_ptr).$field)
+        }
+    }};
+}
+
+/// Computes a const raw pointer to the given field of the given base pointer
+/// to the given parent type.
+///
+/// The `base` pointer *must not* be dangling, but it *may* point to
+/// uninitialized memory.
+#[cfg(not(feature = "unstable_raw"))] // Incorrect (UB) variant that creates an intermediate reference.
 #[macro_export(local_inner_macros)]
 macro_rules! raw_field {
     ($base:expr, $parent:path, $field:tt) => {{


### PR DESCRIPTION
With https://github.com/rust-lang/rust/issues/73394 available on nightly, we can finally provide an actually UB-free version of `offset_of!`. :)