### PR TITLE
some reorganization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ cache:
 matrix:
   include:
   - name: miri
+    env: TRAVIS_MIRI_JOB # make sure the cache is not shared with other "nightly" jobs
     rust: nightly
-    os: linux
     script:
       - sh ci/miri.sh
 
@@ -19,10 +19,10 @@ matrix:
 
   - name: all-features
     rust: nightly
-    os: linux
-    script:  # `--lib` added to prevent doctests from being compiled.
-             # This is due to `unstable_const` requiring extra `feature(...)` directives
-             # which the doctests do not have.
+    script:
+      # `--lib` added to prevent doctests from being compiled.
+      # This is due to `unstable_const` requiring extra `feature(...)` directives
+      # which the doctests do not have.
       - cargo test --verbose --all-features --lib
 
   - name: rustfmt

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -9,3 +9,6 @@ cargo miri setup
 
 cargo miri test
 cargo miri test --all-features
+
+# Restore old state in case Travis uses this cache for other jobs.
+rustup default nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@ pub use core::mem;
 pub use core::ptr;
 
 #[macro_use]
+mod raw_field;
+#[macro_use]
 mod offset_of;
 #[macro_use]
 mod span_of;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
         ptr_offset_from,
         const_ptr_offset_from,
         const_transmute,
-        const_raw_ptr_deref
+        const_raw_ptr_deref,
     )
 )]
 #![cfg_attr(feature = "unstable_raw", feature(raw_ref_macros))]

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -56,7 +56,7 @@ macro_rules! _memoffset_offset_from {
         // Compute offset, with unstable `offset_from` for const-compatibility.
         // (Requires the pointers to not dangle, but we already need that for `raw_field!` anyway.)
         unsafe { ($field as *const u8).offset_from($base as *const u8) as usize }
-    }
+    };
 }
 #[cfg(not(feature = "unstable_const"))]
 #[macro_export]
@@ -65,7 +65,7 @@ macro_rules! _memoffset_offset_from {
     ($field:expr, $base:expr) => {
         // Compute offset.
         ($field as usize) - ($base as usize)
-    }
+    };
 }
 
 /// Calculates the offset of the specified field from the start of the struct.

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -45,65 +45,6 @@ macro_rules! _memoffset__let_base_ptr {
     };
 }
 
-/// Deref-coercion protection macro.
-#[macro_export]
-#[doc(hidden)]
-macro_rules! _memoffset__field_check {
-    ($type:path, $field:tt) => {
-        // Make sure the field actually exists. This line ensures that a
-        // compile-time error is generated if $field is accessed through a
-        // Deref impl.
-        #[cfg_attr(allow_clippy, allow(clippy::unneeded_field_pattern))]
-        let $type { $field: _, .. };
-    };
-}
-
-/// Computes a const raw pointer to the given field of the given base pointer
-/// to the given parent type.
-///
-/// The `base` pointer *must not* be dangling, but it *may* point to
-/// uninitialized memory.
-#[cfg(feature = "unstable_raw")] // Correct variant that uses `raw_const!`.
-#[macro_export(local_inner_macros)]
-macro_rules! raw_field {
-    ($base:expr, $parent:path, $field:tt) => {{
-        _memoffset__field_check!($parent, $field);
-        let base_ptr: *const $parent = $base;
-
-        // Get the field address without creating a reference.
-        // Crucially, we know that this will not trigger a deref coercion because
-        // of the `field_check!` we did above.
-        #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
-        unsafe {
-            $crate::ptr::raw_const!((*base_ptr).$field)
-        }
-    }};
-}
-
-/// Computes a const raw pointer to the given field of the given base pointer
-/// to the given parent type.
-///
-/// The `base` pointer *must not* be dangling, but it *may* point to
-/// uninitialized memory.
-#[cfg(not(feature = "unstable_raw"))] // Incorrect (UB) variant that creates an intermediate reference.
-#[macro_export(local_inner_macros)]
-macro_rules! raw_field {
-    ($base:expr, $parent:path, $field:tt) => {{
-        _memoffset__field_check!($parent, $field);
-        let base_ptr: *const $parent = $base;
-
-        // Get the field address. This is UB because we are creating a reference to
-        // the uninitialized field. Will be updated to use `&raw` before rustc
-        // starts exploiting such UB.
-        // Crucially, we know that this will not trigger a deref coercion because
-        // of the `field_check!` we did above.
-        #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
-        unsafe {
-            &(*base_ptr).$field as *const _
-        }
-    }};
-}
-
 /// Calculates the offset of the specified field from the start of the struct.
 ///
 /// ## Examples

--- a/src/raw_field.rs
+++ b/src/raw_field.rs
@@ -36,28 +36,6 @@ macro_rules! _memoffset__field_check {
 ///
 /// The `base` pointer *must not* be dangling, but it *may* point to
 /// uninitialized memory.
-#[cfg(feature = "unstable_raw")] // Correct variant that uses `raw_const!`.
-#[macro_export(local_inner_macros)]
-macro_rules! raw_field {
-    ($base:expr, $parent:path, $field:tt) => {{
-        _memoffset__field_check!($parent, $field);
-        let base_ptr: *const $parent = $base;
-
-        // Get the field address without creating a reference.
-        // Crucially, we know that this will not trigger a deref coercion because
-        // of the `field_check!` we did above.
-        #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
-        unsafe {
-            $crate::ptr::raw_const!((*base_ptr).$field)
-        }
-    }};
-}
-
-/// Computes a const raw pointer to the given field of the given base pointer
-/// to the given parent type.
-///
-/// The `base` pointer *must not* be dangling, but it *may* point to
-/// uninitialized memory.
 #[cfg(not(feature = "unstable_raw"))] // Incorrect (UB) variant that creates an intermediate reference.
 #[macro_export(local_inner_macros)]
 macro_rules! raw_field {
@@ -73,6 +51,23 @@ macro_rules! raw_field {
         #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
         unsafe {
             &(*base_ptr).$field as *const _
+        }
+    }};
+}
+
+#[cfg(feature = "unstable_raw")] // Correct variant that uses `raw_const!`.
+#[macro_export(local_inner_macros)]
+macro_rules! raw_field {
+    ($base:expr, $parent:path, $field:tt) => {{
+        _memoffset__field_check!($parent, $field);
+        let base_ptr: *const $parent = $base;
+
+        // Get the field address without creating a reference.
+        // Crucially, we know that this will not trigger a deref coercion because
+        // of the `field_check!` we did above.
+        #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
+        unsafe {
+            $crate::ptr::raw_const!((*base_ptr).$field)
         }
     }};
 }

--- a/src/raw_field.rs
+++ b/src/raw_field.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2020 Gilad Naaman, Ralf Jung
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/// Deref-coercion protection macro.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _memoffset__field_check {
+    ($type:path, $field:tt) => {
+        // Make sure the field actually exists. This line ensures that a
+        // compile-time error is generated if $field is accessed through a
+        // Deref impl.
+        #[cfg_attr(allow_clippy, allow(clippy::unneeded_field_pattern))]
+        let $type { $field: _, .. };
+    };
+}
+
+/// Computes a const raw pointer to the given field of the given base pointer
+/// to the given parent type.
+///
+/// The `base` pointer *must not* be dangling, but it *may* point to
+/// uninitialized memory.
+#[cfg(feature = "unstable_raw")] // Correct variant that uses `raw_const!`.
+#[macro_export(local_inner_macros)]
+macro_rules! raw_field {
+    ($base:expr, $parent:path, $field:tt) => {{
+        _memoffset__field_check!($parent, $field);
+        let base_ptr: *const $parent = $base;
+
+        // Get the field address without creating a reference.
+        // Crucially, we know that this will not trigger a deref coercion because
+        // of the `field_check!` we did above.
+        #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
+        unsafe {
+            $crate::ptr::raw_const!((*base_ptr).$field)
+        }
+    }};
+}
+
+/// Computes a const raw pointer to the given field of the given base pointer
+/// to the given parent type.
+///
+/// The `base` pointer *must not* be dangling, but it *may* point to
+/// uninitialized memory.
+#[cfg(not(feature = "unstable_raw"))] // Incorrect (UB) variant that creates an intermediate reference.
+#[macro_export(local_inner_macros)]
+macro_rules! raw_field {
+    ($base:expr, $parent:path, $field:tt) => {{
+        _memoffset__field_check!($parent, $field);
+        let base_ptr: *const $parent = $base;
+
+        // Get the field address. This is UB because we are creating a reference to
+        // the uninitialized field. Will be updated to use `&raw` before rustc
+        // starts exploiting such UB.
+        // Crucially, we know that this will not trigger a deref coercion because
+        // of the `field_check!` we did above.
+        #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
+        unsafe {
+            &(*base_ptr).$field as *const _
+        }
+    }};
+}


### PR DESCRIPTION
* Move `raw_field!` to its own file, and extract the "create raw ptr" part into a sub-macro so that all the rest of the code can be shared.
* Use `raw_field!` in `span_of!`. This means we do not even need the field check as a separate macro any more.
* Extract the ptr-diff computation in a sub-macro so that `offset_of!` is always the same macro, just its sub-macros differ depending on compiler version and feature flags.