### PR TITLE
Remove const_transmute feature dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Your crate root: (`lib.rs`/`main.rs`)
 
 Or, if you intend to use `offset_of!` inside a `const fn`:
 ```rust,ignore
-#![feature(ptr_offset_from, const_fn_transmute, const_ptr_offset_from, const_raw_ptr_deref)]
+#![feature(ptr_offset_from, const_fn, const_fn_transmute, const_ptr_offset_from, const_raw_ptr_deref)]
 ```
 
 and then:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ features = ["unstable_const"]
 
 Your crate root: (`lib.rs`/`main.rs`)
 ```rust,ignore
-#![feature(ptr_offset_from, const_ptr_offset_from, const_transmute, const_raw_ptr_deref)]
+#![feature(ptr_offset_from, const_ptr_offset_from, const_raw_ptr_deref)]
 ```
 
 and then:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Your crate root: (`lib.rs`/`main.rs`)
 #![feature(ptr_offset_from, const_ptr_offset_from, const_raw_ptr_deref)]
 ```
 
+Or, if you intend to use `offset_of!` inside a `const fn`:
+```rust,ignore
+#![feature(ptr_offset_from, const_fn_transmute, const_ptr_offset_from, const_raw_ptr_deref)]
+```
+
 and then:
 
 ```rust,ignore

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@
     feature(
         ptr_offset_from,
         const_ptr_offset_from,
-        const_transmute,
         const_raw_ptr_deref,
     )
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@
     feature = "unstable_const",
     feature(
         ptr_offset_from,
+        const_fn,
+        const_fn_transmute,
         const_ptr_offset_from,
         const_raw_ptr_deref,
     )

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -206,9 +206,9 @@ mod tests {
                 c: i64,
             }
 
-             offset_of!(Foo, b)
+            offset_of!(Foo, b)
         }
 
-        assert_eq!([0;test_fn()].len(), 4);
+        assert_eq!([0; test_fn()].len(), 4);
     }
 }

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -194,4 +194,21 @@ mod tests {
 
         assert_eq!([0; offset_of!(Foo, b)].len(), 4);
     }
+
+    #[cfg(feature = "unstable_const")]
+    #[test]
+    fn const_fn_offset() {
+        const fn test_fn() -> usize {
+            #[repr(C)]
+            struct Foo {
+                a: u32,
+                b: [u8; 2],
+                c: i64,
+            }
+
+             offset_of!(Foo, b)
+        }
+
+        assert_eq!([0;test_fn()].len(), 4);
+    }
 }


### PR DESCRIPTION
`const_transmute` seems to have been stabilized on current nightly, see https://github.com/rust-lang/rust/pull/72920. This caused an unrecognized feature flag error when compiling against nightly.