### PR TITLE
use MaybeUninit::as_ptr instead of transmute

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,24 +68,10 @@ features = ["unstable_const"]
 
 Your crate root: (`lib.rs`/`main.rs`)
 ```rust,ignore
-#![feature(ptr_offset_from, const_ptr_offset_from, const_raw_ptr_deref)]
+#![feature(ptr_offset_from, const_ptr_offset_from, const_maybe_uninit_as_ptr, const_raw_ptr_deref)]
 ```
 
-Or, if you intend to use `offset_of!` inside a `const fn`:
-```rust,ignore
-#![feature(ptr_offset_from, const_fn, const_fn_transmute, const_ptr_offset_from, const_raw_ptr_deref)]
-```
-
-and then:
-
-```rust,ignore
-struct Foo {
-    a: u32,
-    b: u32,
-}
-
-let foo = [0; offset_of!(Foo, b)] 
-```
+If you intend to use `offset_of!` inside a `const fn`, also add the `const_fn` compiler feature.
 
 ### Raw references ###
 Recent nightlies support [a way to create raw pointers](https://github.com/rust-lang/rust/issues/73394) that avoids creating intermediate safe references.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,8 @@
     feature(
         ptr_offset_from,
         const_fn,
-        const_fn_transmute,
         const_ptr_offset_from,
+        const_maybe_uninit_as_ptr,
         const_raw_ptr_deref,
     )
 )]

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -31,9 +31,7 @@ macro_rules! _memoffset__let_base_ptr {
         // `let_base_ptr` declares a variable (several, actually)
         // instead of returning one.
         let uninit = $crate::mem::MaybeUninit::<$type>::uninit();
-        // Transmuting for const-compatibility.
-        #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
-        let $name: *const $type = unsafe { $crate::mem::transmute(&uninit) };
+        let $name: *const $type = uninit.as_ptr();
     };
 }
 #[cfg(not(maybe_uninit))]


### PR DESCRIPTION
With https://github.com/rust-lang/rust/pull/75250 having landed, we can finally get rid of the `transmute` here.