### PR TITLE
Use stablilized addr_of macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,3 @@ doc-comment = "0.3"
 [features]
 default = []
 unstable_const = []
-unstable_raw = []

--- a/README.md
+++ b/README.md
@@ -73,8 +73,3 @@ Your crate root: (`lib.rs`/`main.rs`)
 ```
 
 If you intend to use `offset_of!` inside a `const fn`, also add the `const_fn` compiler feature.
-
-### Raw references ###
-Recent nightlies support [a way to create raw pointers](https://github.com/rust-lang/rust/issues/73394) that avoids creating intermediate safe references.
-`memoffset` can make use of that feature to avoid what is technically Undefined Behavior.
-Use the `unstable_raw` feature to enable this.

--- a/build.rs
+++ b/build.rs
@@ -16,4 +16,7 @@ fn main() {
     if ac.probe_rustc_version(1, 40) {
         println!("cargo:rustc-cfg=doctests");
     }
+    if ac.probe_rustc_version(1, 51) {
+        println!("cargo:rustc-cfg=raw_ref_macros");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,6 @@
         const_raw_ptr_deref,
     )
 )]
-#![cfg_attr(feature = "unstable_raw", feature(raw_ref_macros))]
 
 #[macro_use]
 #[cfg(doctests)]

--- a/src/raw_field.rs
+++ b/src/raw_field.rs
@@ -18,22 +18,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/// `raw_const!`, or just ref-then-cast when that is not available.
-#[cfg(feature = "unstable_raw")]
+/// `addr_of!`, or just ref-then-cast when that is not available.
+#[cfg(raw_ref_macros)]
 #[macro_export]
 #[doc(hidden)]
-macro_rules! _memoffset__raw_const {
+macro_rules! _memoffset__addr_of {
     ($path:expr) => {{
-        $crate::ptr::raw_const!($path)
+        $crate::ptr::addr_of!($path)
     }};
 }
-#[cfg(not(feature = "unstable_raw"))]
+#[cfg(not(raw_ref_macros))]
 #[macro_export]
 #[doc(hidden)]
-macro_rules! _memoffset__raw_const {
+macro_rules! _memoffset__addr_of {
     ($path:expr) => {{
         // This is UB because we create an intermediate reference to uninitialized memory.
-        // Nothing we can do about that without `raw_const!` though.
+        // Nothing we can do about that without `addr_of!` though.
         &$path as *const _
     }};
 }
@@ -88,7 +88,7 @@ macro_rules! raw_field {
         // of the field check we did above.
         #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
         unsafe {
-            _memoffset__raw_const!((*($base as *const $parent)).$field)
+            _memoffset__addr_of!((*($base as *const $parent)).$field)
         }
     }};
 }
@@ -109,7 +109,7 @@ macro_rules! raw_field_tuple {
         // of the field check we did above.
         #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
         unsafe {
-            _memoffset__raw_const!((*($base as *const $parent)).$field)
+            _memoffset__addr_of!((*($base as *const $parent)).$field)
         }
     }};
 }


### PR DESCRIPTION
Since Rust 1.51.0, support for macro addr_of!() has been stabilized[1],
and this provides a way to get a raw pointer without potential UB in
some cases.

Memoffset alreadly uses the feature at the pre-stablilized stage (the
macro was named as raw_const then). Therefore, switch to use the
stablilized version (and name) and remove the out-dated version, also
remove the related feature gate.

[1]: https://github.com/rust-lang/rust/pull/72279

Signed-off-by: Boqun Feng <boqun.feng@gmail.com>