### PR TITLE
Make span_of sound

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ matrix:
       - sh ci/miri.sh
 
   - rust: 1.19.0  # Oldest supported (first version with numeric fields in struct patterns)
+  - rust: 1.20.0  # Oldest supported with tuple_ty
   - rust: 1.31.0  # Oldest supported with allow(clippy)
   - rust: 1.36.0  # Oldest supported with MaybeUninit
+  - rust: 1.40.0  # Oldest supported with cfg(doctest)
+  - rust: 1.51.0  # Oldest supported with ptr::addr_of!
   - rust: stable
   - rust: beta
   - rust: nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub mod __priv {
     /// Use type inference to obtain the size of the pointee (without actually using the pointer).
     #[doc(hidden)]
     pub fn size_of_pointee<T>(_ptr: *const T) -> usize {
-        core::mem::size_of::<T>()
+        mem::size_of::<T>()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,16 @@ pub use core::mem;
 #[doc(hidden)]
 pub use core::ptr;
 
+/// Hiden module to things the macros need to access.
+#[doc(hidden)]
+pub mod __priv {
+    /// Use type inference to obtain the size of the pointee (without actually using the pointer).
+    #[doc(hidden)]
+    pub fn size_of_pointee<T>(_ptr: *const T) -> usize {
+        core::mem::size_of::<T>()
+    }
+}
+
 #[macro_use]
 mod raw_field;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,16 +76,14 @@ extern crate doc_comment;
 #[cfg(doctest)]
 doctest!("../README.md");
 
-// This `use` statement enables the macros to use `$crate::mem`.
-// Doing this enables this crate to function under both std and no-std crates.
-#[doc(hidden)]
-pub use core::mem;
-#[doc(hidden)]
-pub use core::ptr;
-
-/// Hiden module to things the macros need to access.
+/// Hiden module for things the macros need to access.
 #[doc(hidden)]
 pub mod __priv {
+    #[doc(hidden)]
+    pub use core::mem;
+    #[doc(hidden)]
+    pub use core::ptr;
+
     /// Use type inference to obtain the size of the pointee (without actually using the pointer).
     #[doc(hidden)]
     pub fn size_of_pointee<T>(_ptr: *const T) -> usize {

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -49,7 +49,7 @@ macro_rules! _memoffset__let_base_ptr {
 #[cfg(feature = "unstable_const")]
 #[macro_export]
 #[doc(hidden)]
-macro_rules! _memoffset_offset_from {
+macro_rules! _memoffset_offset_from_unsafe {
     ($field:expr, $base:expr) => {{
         let field = $field; // evaluate $field outside the `unsafe` block
         let base = $base; // evaluate $base outside the `unsafe` block
@@ -61,7 +61,7 @@ macro_rules! _memoffset_offset_from {
 #[cfg(not(feature = "unstable_const"))]
 #[macro_export]
 #[doc(hidden)]
-macro_rules! _memoffset_offset_from {
+macro_rules! _memoffset_offset_from_unsafe {
     ($field:expr, $base:expr) => {
         // Compute offset.
         ($field as usize) - ($base as usize)
@@ -95,7 +95,7 @@ macro_rules! offset_of {
         // Get field pointer.
         let field_ptr = raw_field!(base_ptr, $parent, $field);
         // Compute offset.
-        _memoffset_offset_from!(field_ptr, base_ptr)
+        _memoffset_offset_from_unsafe!(field_ptr, base_ptr)
     }};
 }
 
@@ -119,7 +119,7 @@ macro_rules! offset_of_tuple {
         // Get field pointer.
         let field_ptr = raw_field_tuple!(base_ptr, $parent, $field);
         // Compute offset.
-        _memoffset_offset_from!(field_ptr, base_ptr)
+        _memoffset_offset_from_unsafe!(field_ptr, base_ptr)
     }};
 }
 

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -30,7 +30,7 @@ macro_rules! _memoffset__let_base_ptr {
         // so it has to be in the same scope as `$name`. That's why
         // `let_base_ptr` declares a variable (several, actually)
         // instead of returning one.
-        let uninit = $crate::mem::MaybeUninit::<$type>::uninit();
+        let uninit = $crate::__priv::mem::MaybeUninit::<$type>::uninit();
         let $name: *const $type = uninit.as_ptr();
     };
 }
@@ -41,7 +41,7 @@ macro_rules! _memoffset__let_base_ptr {
     ($name:ident, $type:ty) => {
         // No UB right here, but we will later dereference this pointer to
         // offset into a field, and that is UB because the pointer is dangling.
-        let $name = $crate::mem::align_of::<$type>() as *const $type;
+        let $name = $crate::__priv::mem::align_of::<$type>() as *const $type;
     };
 }
 

--- a/src/raw_field.rs
+++ b/src/raw_field.rs
@@ -24,7 +24,7 @@
 #[doc(hidden)]
 macro_rules! _memoffset__addr_of {
     ($path:expr) => {{
-        $crate::ptr::addr_of!($path)
+        $crate::__priv::ptr::addr_of!($path)
     }};
 }
 #[cfg(not(raw_ref_macros))]


### PR DESCRIPTION
Fixes https://github.com/Gilnaa/memoffset/issues/52

While at it I also fixed some minor things:
- rename `_memoffset_offset_from macro` to reflect that it is unsafe to call (internal macro, so this is not semver-breaking)
- test all versions on Travis that are significant in build.rs