### PR TITLE
update feature flags and docs for const offset_of

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ features = ["unstable_const"]
 
 Your crate root: (`lib.rs`/`main.rs`)
 ```rust,ignore
-#![feature(ptr_offset_from, const_ptr_offset_from, const_maybe_uninit_as_ptr, const_raw_ptr_deref)]
+#![feature(const_ptr_offset_from, const_maybe_uninit_as_ptr, const_raw_ptr_deref, const_refs_to_cell)]
 ```
 
 If you intend to use `offset_of!` inside a `const fn`, also add the `const_fn` compiler feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,11 +60,10 @@
 #![cfg_attr(
     feature = "unstable_const",
     feature(
-        ptr_offset_from,
-        const_fn,
         const_ptr_offset_from,
         const_maybe_uninit_as_ptr,
         const_raw_ptr_deref,
+        const_refs_to_cell,
     )
 )]
 

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -255,6 +255,18 @@ mod tests {
 
     #[cfg(feature = "unstable_const")]
     #[test]
+    fn const_offset_interior_mutable() {
+        #[repr(C)]
+        struct Foo {
+            a: u32,
+            b: core::cell::Cell<u32>,
+        }
+
+        assert_eq!([0; offset_of!(Foo, b)].len(), 4);
+    }
+
+    #[cfg(feature = "unstable_const")]
+    #[test]
     fn const_fn_offset() {
         const fn test_fn() -> usize {
             #[repr(C)]


### PR DESCRIPTION
Fixes https://github.com/Gilnaa/memoffset/issues/37

While at it I also removed `ptr_offset_from` since that feature is stable for a while already.