### PR TITLE
the const_fn compiler feature is a NOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,3 @@ Your crate root: (`lib.rs`/`main.rs`)
 ```rust,ignore
 #![feature(const_ptr_offset_from, const_maybe_uninit_as_ptr, const_raw_ptr_deref, const_refs_to_cell)]
 ```
-
-If you intend to use `offset_of!` inside a `const fn`, also add the `const_fn` compiler feature.


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/84510 -- the `const_fn` feature gate does not actually do anything any more and will be removed soon.