### PR TITLE
Fix `unstable_const` for the latest compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ features = ["unstable_const"]
 
 Your crate root: (`lib.rs`/`main.rs`)
 ```rust,ignore
-#![feature(const_ptr_offset_from, const_raw_ptr_deref, const_refs_to_cell)]
+#![feature(const_ptr_offset_from, const_refs_to_cell)]
 ```

--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ features = ["unstable_const"]
 
 Your crate root: (`lib.rs`/`main.rs`)
 ```rust,ignore
-#![feature(const_ptr_offset_from, const_maybe_uninit_as_ptr, const_raw_ptr_deref, const_refs_to_cell)]
+#![feature(const_ptr_offset_from, const_raw_ptr_deref, const_refs_to_cell)]
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 #![no_std]
 #![cfg_attr(
     feature = "unstable_const",
-    feature(const_ptr_offset_from, const_raw_ptr_deref, const_refs_to_cell)
+    feature(const_ptr_offset_from, const_refs_to_cell)
 )]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,12 +58,7 @@
 #![no_std]
 #![cfg_attr(
     feature = "unstable_const",
-    feature(
-        const_ptr_offset_from,
-        const_maybe_uninit_as_ptr,
-        const_raw_ptr_deref,
-        const_refs_to_cell,
-    )
+    feature(const_ptr_offset_from, const_raw_ptr_deref, const_refs_to_cell)
 )]
 
 #[macro_use]


### PR DESCRIPTION
This PR removes some of `#![feature(...)]`s for compatibility with the latest nightly compiler.

- `const_maybe_uninit_as_ptr` has been stabilized by <https://github.com/rust-lang/rust/pull/90896> and is not recognized by the compiler anymore.

- `const_raw_ptr_deref` has been stabilized by <https://github.com/rust-lang/rust/pull/89551>.