### PR TITLE
Suppress `clippy::unneeded_wildcard_pattern`

### DIFF
--- a/src/raw_field.rs
+++ b/src/raw_field.rs
@@ -64,6 +64,17 @@ macro_rules! _memoffset__field_check {
 }
 
 /// Deref-coercion protection macro.
+#[cfg(allow_clippy)]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _memoffset__field_check_tuple {
+    ($type:ty, $field:tt) => {
+        // Make sure the type argument is a tuple
+        #[allow(clippy::unneeded_wildcard_pattern)]
+        let (_, ..): $type;
+    };
+}
+#[cfg(not(allow_clippy))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! _memoffset__field_check_tuple {


### PR DESCRIPTION
This PR fixes `offset_of_tuple!` causing clippy warnings in consumer code.

```
warning: this pattern is unneeded as the `..` pattern can match that element
   --> src/raw_field.rs:74:14
    |
74  |         let (_, ..): $type;
    |              ^^^ help: remove it
    |
   ::: src/lib.rs:101:9
    |
101 |         offset_of_tuple!((i32, f32, u8), 1)
    |         ----------------------------------- in this macro invocation
    |
    = note: `#[warn(clippy::unneeded_wildcard_pattern)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_wildcard_pattern
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```