### PR TITLE
Support unions in offset_of(_union)

### DIFF
--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -139,9 +139,9 @@ macro_rules! offset_of_tuple {
 /// ```
 ///
 /// ## Note
-/// Due to macro_rules limitations, this check will accept structs with a single field as well as unions.
-/// Using this macro for a single-field struct will still work, but might lead to a future
-/// compatibility problem if the struct gains more fields.
+/// Due to macro_rules limitations, this macro will accept structs with a single field as well as unions.
+/// This is not a stable guarantee, and future versions of this crate might fail
+/// on any use of this macro with a struct, without a semver bump.
 #[macro_export(local_inner_macros)]
 macro_rules! offset_of_union {
     ($parent:path, $field:tt) => {{

--- a/src/raw_field.rs
+++ b/src/raw_field.rs
@@ -84,6 +84,41 @@ macro_rules! _memoffset__field_check_tuple {
     };
 }
 
+/// Deref-coercion protection macro for unions.
+/// Unfortunately accepts single-field structs as well, which is not ideal,
+/// but ultimately pretty harmless.
+#[cfg(allow_clippy)]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _memoffset__field_check_union {
+    ($type:path, $field:tt) => {
+        // Make sure the field actually exists. This line ensures that a
+        // compile-time error is generated if $field is accessed through a
+        // Deref impl.
+        #[allow(clippy::unneeded_wildcard_pattern)]
+        // rustc1.19 requires unsafe here for the pattern; not needed in newer versions
+        #[allow(unused_unsafe)]
+        unsafe {
+            let $type { $field: _ };
+        }
+    };
+}
+#[cfg(not(allow_clippy))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _memoffset__field_check_union {
+    ($type:path, $field:tt) => {
+        // Make sure the field actually exists. This line ensures that a
+        // compile-time error is generated if $field is accessed through a
+        // Deref impl.
+        // rustc1.19 requires unsafe here for the pattern; not needed in newer versions
+        #[allow(unused_unsafe)]
+        unsafe {
+            let $type { $field: _ };
+        }
+    };
+}
+
 /// Computes a const raw pointer to the given field of the given base pointer
 /// to the given parent type.
 ///
@@ -115,6 +150,34 @@ macro_rules! raw_field {
 macro_rules! raw_field_tuple {
     ($base:expr, $parent:ty, $field:tt) => {{
         _memoffset__field_check_tuple!($parent, $field);
+        let base = $base; // evaluate $base outside the `unsafe` block
+
+        // Get the field address.
+        // Crucially, we know that this will not trigger a deref coercion because
+        // of the field check we did above.
+        #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
+        unsafe {
+            _memoffset__addr_of!((*(base as *const $parent)).$field)
+        }
+    }};
+}
+
+/// Computes a const raw pointer to the given field of the given base pointer
+/// to the given parent tuple typle.
+///
+/// The `base` pointer *must not* be dangling, but it *may* point to
+/// uninitialized memory.
+///
+/// ## Note
+/// This macro is the same as `raw_field`, except for a different Deref-coercion check that
+/// supports unions.
+/// Due to macro_rules limitations, this check will accept structs with a single field as well as unions.
+/// Using this macro for a single-field struct will still work, but might lead to a future
+/// compatibility problem if the struct gains more fields.
+#[macro_export(local_inner_macros)]
+macro_rules! raw_field_union {
+    ($base:expr, $parent:path, $field:tt) => {{
+        _memoffset__field_check_union!($parent, $field);
         let base = $base; // evaluate $base outside the `unsafe` block
 
         // Get the field address.

--- a/src/raw_field.rs
+++ b/src/raw_field.rs
@@ -172,8 +172,8 @@ macro_rules! raw_field_tuple {
 /// This macro is the same as `raw_field`, except for a different Deref-coercion check that
 /// supports unions.
 /// Due to macro_rules limitations, this check will accept structs with a single field as well as unions.
-/// Using this macro for a single-field struct will still work, but might lead to a future
-/// compatibility problem if the struct gains more fields.
+/// This is not a stable guarantee, and future versions of this crate might fail
+/// on any use of this macro with a struct, without a semver bump.
 #[macro_export(local_inner_macros)]
 macro_rules! raw_field_union {
     ($base:expr, $parent:path, $field:tt) => {{


### PR DESCRIPTION
Closes https://github.com/Gilnaa/memoffset/issues/66

Note that the matcher for union type is `$parent:path` all throughout; otherwise you get `error: expected identifier, found STRUCT_NAME` when attempting to expand the macro.
I have to admit I'm not sure what's the significance of this. (Original offset_of uses `:path`, tuple uses `:ty`)