### PR TITLE
Add some compile-fail tests.

### DIFF
--- a/src/raw_field.rs
+++ b/src/raw_field.rs
@@ -39,6 +39,21 @@ macro_rules! _memoffset__addr_of {
 }
 
 /// Deref-coercion protection macro.
+///
+/// Prevents complilation if the specified field name is not a part of the
+/// struct definition.
+///
+/// ```compile_fail
+/// use memoffset::_memoffset__field_check;
+///
+/// struct Foo {
+///     foo: i32,
+/// }
+///
+/// type BoxedFoo = Box<Foo>;
+///
+/// _memoffset__field_check!(BoxedFoo, foo);
+/// ```
 #[cfg(allow_clippy)]
 #[macro_export]
 #[doc(hidden)]
@@ -64,6 +79,14 @@ macro_rules! _memoffset__field_check {
 }
 
 /// Deref-coercion protection macro.
+///
+/// Prevents complilation if the specified type is not a tuple.
+///
+/// ```compile_fail
+/// use memoffset::_memoffset__field_check_tuple;
+///
+/// _memoffset__field_check_tuple!(i32, 0);
+/// ```
 #[cfg(allow_clippy)]
 #[macro_export]
 #[doc(hidden)]
@@ -87,6 +110,18 @@ macro_rules! _memoffset__field_check_tuple {
 /// Deref-coercion protection macro for unions.
 /// Unfortunately accepts single-field structs as well, which is not ideal,
 /// but ultimately pretty harmless.
+///
+/// ```compile_fail
+/// use memoffset::_memoffset__field_check_union;
+///
+/// union Foo {
+///     variant_a: i32,
+/// }
+///
+/// type BoxedFoo = Box<Foo>;
+///
+/// _memoffset__field_check_union!(BoxedFoo, variant_a);
+/// ```
 #[cfg(allow_clippy)]
 #[macro_export]
 #[doc(hidden)]


### PR DESCRIPTION
Ticket:
 - https://github.com/Gilnaa/memoffset/issues/23

The compilation failures look like this: (after applying [this](https://github.com/Gilnaa/memoffset/pull/68#discussion_r991552583) suggestion)
```
successes:

---- src/raw_field.rs - raw_field::_memoffset__field_check_tuple (line 82) stdout ----
error[E0308]: mismatched types
 --> src/raw_field.rs:85:1
  |
6 | _memoffset__field_check_tuple!(i32, 0);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^^^
  | |                              |
  | |                              expected due to this
  | expected `i32`, found tuple
  |
  = note: expected type `i32`
            found tuple `(_,)`
  = note: this error originates in the macro `_memoffset__field_check_tuple` (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
```
```
---- src/raw_field.rs - raw_field::_memoffset__field_check (line 46) stdout ----
error[E0026]: struct `Box` does not have a field named `foo`
 --> src/raw_field.rs:52:36
  |
9 | _memoffset__field_check!(BoxedFoo, foo);
  |                                    ^^^ struct `Box` does not have this field

error: aborting due to previous error

For more information about this error, try `rustc --explain E0026`.
```
```
---- src/raw_field.rs - raw_field::_memoffset__field_check_union (line 111) stdout ----
error[E0769]: tuple variant `BoxedFoo` written as struct variant
  --> src/raw_field.rs:120:1
   |
12 | _memoffset__field_check_union!(BoxedFoo, variant_a);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `_memoffset__field_check_union` (in Nightly builds, run with -Z macro-backtrace for more info)
help: use the tuple variant pattern syntax instead
  --> /home/gilad/src/memoffset/src/raw_field.rs:134:36
   |
134|             let $type { $field: _ }(_, _);
   |                                    ++++++

error: aborting due to previous error

For more information about this error, try `rustc --explain E0769`.

---- src/offset_of.rs - offset_of::offset_of_tuple (line 104) stdout ----
```
