### PR TITLE
Automatically enable const evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - 1.36.0  # Oldest supported with MaybeUninit
           - 1.40.0  # Oldest supported with cfg(doctest)
           - 1.51.0  # Oldest supported with ptr::addr_of!
+          - 1.65.0  # Oldest supported with stable const evaluation (sans cell)
           - stable
           - beta
           - nightly

--- a/README.md
+++ b/README.md
@@ -45,12 +45,23 @@ fn main() {
 }
 ```
 
-## Feature flags ##
+## Usage in constants ##
+`memoffset` has support for compile-time `offset_of!` on rust>=1.65, or on older nightly compilers.
 
-### Usage in constants ###
-`memoffset` has **experimental** support for compile-time `offset_of!` on a nightly compiler.
+### Usage on stable Rust ###
+Constant evaluation is automatically enabled and avilable on stable compilers starting with rustc 1.65.
 
-In order to use it, you must enable the `unstable_const` crate feature and several compiler features.
+This is an incomplete implementation with one caveat:
+Due to dependence on [`#![feature(const_refs_to_cell)]`](https://github.com/rust-lang/rust/issues/80384), you cannot get the offset of a `Cell` field in a const-context.
+
+This means that if need to get the offset of a cell, you'll have to remain on nightly for now.
+
+### Usage on recent nightlies ###
+
+If you're using a new-enough nightly and you require the ability to get the offset of a `Cell`,
+you'll have to enable the `unstable_const` cargo feature, as well as enabling `const_refs_to_cell` in your crate root.
+
+Do note that `unstable_const` is an unstable feature that is set to be removed in a future version of `memoffset`.
 
 Cargo.toml:
 ```toml
@@ -58,6 +69,14 @@ Cargo.toml:
 version = "0.7"
 features = ["unstable_const"]
 ```
+
+Your crate root: (`lib.rs`/`main.rs`)
+```rust,ignore
+#![feature(const_refs_to_cell)]
+```
+
+### Usage on older nightlies ###
+In order to use it on an older nightly compiler, you must enable the `unstable_const` crate feature and several compiler features.
 
 Your crate root: (`lib.rs`/`main.rs`)
 ```rust,ignore

--- a/build.rs
+++ b/build.rs
@@ -19,4 +19,7 @@ fn main() {
     if ac.probe_rustc_version(1, 51) {
         println!("cargo:rustc-cfg=raw_ref_macros");
     }
+    if ac.probe_rustc_version(1, 65) {
+        println!("cargo:rustc-cfg=stable_const");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,10 @@
 
 #![no_std]
 #![cfg_attr(
-    feature = "unstable_const",
-    feature(const_ptr_offset_from, const_refs_to_cell)
+    all(feature = "unstable_const", not(stable_const)),
+    feature(const_ptr_offset_from)
 )]
+#![cfg_attr(feature = "unstable_const", feature(const_refs_to_cell))]
 
 #[macro_use]
 #[cfg(doctests)]

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -46,7 +46,7 @@ macro_rules! _memoffset__let_base_ptr {
 }
 
 /// Macro to compute the distance between two pointers.
-#[cfg(feature = "unstable_const")]
+#[cfg(any(feature = "unstable_const", stable_const))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! _memoffset_offset_from_unsafe {
@@ -58,7 +58,7 @@ macro_rules! _memoffset_offset_from_unsafe {
         unsafe { (field as *const u8).offset_from(base as *const u8) as usize }
     }};
 }
-#[cfg(not(feature = "unstable_const"))]
+#[cfg(not(any(feature = "unstable_const", stable_const)))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! _memoffset_offset_from_unsafe {
@@ -312,7 +312,7 @@ mod tests {
         assert_eq!(f_ptr as usize + 0, raw_field_union!(f_ptr, Foo, c) as usize);
     }
 
-    #[cfg(feature = "unstable_const")]
+    #[cfg(any(feature = "unstable_const", stable_const))]
     #[test]
     fn const_offset() {
         #[repr(C)]
@@ -337,7 +337,7 @@ mod tests {
         assert_eq!([0; offset_of!(Foo, b)].len(), 4);
     }
 
-    #[cfg(feature = "unstable_const")]
+    #[cfg(any(feature = "unstable_const", stable_const))]
     #[test]
     fn const_fn_offset() {
         const fn test_fn() -> usize {


### PR DESCRIPTION
When running on a compiler newer than 1.65,
automatically enable usage of the macro in const contexts.

Closes https://github.com/Gilnaa/memoffset/issues/4
Though we'll have to open a new one to track const-usage with cells.