### PR TITLE
Add unstable_offset_of feature to use the unstable offset_of macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ doc-comment = "0.3"
 [features]
 default = []
 unstable_const = []
+unstable_offset_of = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@
     feature(const_ptr_offset_from)
 )]
 #![cfg_attr(feature = "unstable_const", feature(const_refs_to_cell))]
+#![cfg_attr(feature = "unstable_offset_of", feature(allow_internal_unstable))]
 
 #[macro_use]
 #[cfg(doctests)]

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -67,6 +67,28 @@ macro_rules! _memoffset_offset_from_unsafe {
         ($field as usize) - ($base as usize)
     };
 }
+#[cfg(not(feature = "unstable_offset_of"))]
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! _memoffset__offset_of_impl {
+    ($parent:path, $field:tt) => {{
+        // Get a base pointer (non-dangling if rustc supports `MaybeUninit`).
+        _memoffset__let_base_ptr!(base_ptr, $parent);
+        // Get field pointer.
+        let field_ptr = raw_field!(base_ptr, $parent, $field);
+        // Compute offset.
+        _memoffset_offset_from_unsafe!(field_ptr, base_ptr)
+    }};
+}
+#[cfg(feature = "unstable_offset_of")]
+#[macro_export]
+#[doc(hidden)]
+#[allow_internal_unstable(offset_of)]
+macro_rules! _memoffset__offset_of_impl {
+    ($parent:path, $field:tt) => {{
+        $crate::__priv::mem::offset_of!($parent, $field)
+    }};
+}
 
 /// Calculates the offset of the specified field from the start of the named struct.
 ///
@@ -98,14 +120,9 @@ macro_rules! _memoffset_offset_from_unsafe {
 /// As a result, the value should not be retained and used between different compilations.
 #[macro_export(local_inner_macros)]
 macro_rules! offset_of {
-    ($parent:path, $field:tt) => {{
-        // Get a base pointer (non-dangling if rustc supports `MaybeUninit`).
-        _memoffset__let_base_ptr!(base_ptr, $parent);
-        // Get field pointer.
-        let field_ptr = raw_field!(base_ptr, $parent, $field);
-        // Compute offset.
-        _memoffset_offset_from_unsafe!(field_ptr, base_ptr)
-    }};
+    ($parent:path, $field:tt) => {
+        _memoffset__offset_of_impl!($parent, $field)
+    };
 }
 
 /// Calculates the offset of the specified field from the start of the tuple.
@@ -128,6 +145,30 @@ macro_rules! offset_of_tuple {
         let field_ptr = raw_field_tuple!(base_ptr, $parent, $field);
         // Compute offset.
         _memoffset_offset_from_unsafe!(field_ptr, base_ptr)
+    }};
+}
+
+#[cfg(not(feature = "unstable_offset_of"))]
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! _memoffset__offset_of_union_impl {
+    ($parent:path, $field:tt) => {{
+        // Get a base pointer (non-dangling if rustc supports `MaybeUninit`).
+        _memoffset__let_base_ptr!(base_ptr, $parent);
+        // Get field pointer.
+        let field_ptr = raw_field_union!(base_ptr, $parent, $field);
+        // Compute offset.
+        _memoffset_offset_from_unsafe!(field_ptr, base_ptr)
+    }};
+}
+
+#[cfg(feature = "unstable_offset_of")]
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+#[allow_internal_unstable(offset_of)]
+macro_rules! _memoffset__offset_of_union_impl {
+    ($parent:path, $field:tt) => {{
+        $crate::__priv::mem::offset_of!($parent, $field)
     }};
 }
 
@@ -155,12 +196,7 @@ macro_rules! offset_of_tuple {
 #[macro_export(local_inner_macros)]
 macro_rules! offset_of_union {
     ($parent:path, $field:tt) => {{
-        // Get a base pointer (non-dangling if rustc supports `MaybeUninit`).
-        _memoffset__let_base_ptr!(base_ptr, $parent);
-        // Get field pointer.
-        let field_ptr = raw_field_union!(base_ptr, $parent, $field);
-        // Compute offset.
-        _memoffset_offset_from_unsafe!(field_ptr, base_ptr)
+        _memoffset__offset_of_union_impl!($parent, $field)
     }};
 }
 
@@ -312,7 +348,11 @@ mod tests {
         assert_eq!(f_ptr as usize + 0, raw_field_union!(f_ptr, Foo, c) as usize);
     }
 
-    #[cfg(any(feature = "unstable_const", stable_const))]
+    #[cfg(any(
+        feature = "unstable_const",
+        feature = "unstable_offset_of",
+        stable_const
+    ))]
     #[test]
     fn const_offset() {
         #[repr(C)]
@@ -337,7 +377,11 @@ mod tests {
         assert_eq!([0; offset_of!(Foo, b)].len(), 4);
     }
 
-    #[cfg(any(feature = "unstable_const", stable_const))]
+    #[cfg(any(
+        feature = "unstable_const",
+        feature = "unstable_offset_of",
+        stable_const
+    ))]
     #[test]
     fn const_fn_offset() {
         const fn test_fn() -> usize {


### PR DESCRIPTION
Add a cargo feature `unstable_offset_of` to use the unstable [`core::mem::offset_of!()`](https://doc.rust-lang.org/nightly/core/mem/macro.offset_of.html) macro (https://github.com/rust-lang/rust/issues/106655). This allows for unsized structs (#25) and many other things. It also helps with [testing](https://github.com/rust-lang/rust/issues/106655#issuecomment-1548916780) of the upstream `offset_of` macro: testing is now as easy as enabling this feature, one doesn't have to change the usages from `memoffset::offset_of` to `core::mem::offset_of`.