### PR TITLE
clippy: Suppress `identity_op` lint.

### DIFF
--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -200,6 +200,8 @@ macro_rules! offset_of_union {
 
 #[cfg(test)]
 mod tests {
+    #![cfg_attr(allow_clippy, allow(clippy::identity_op))] // For `... + 0` constructs below.
+
     #[test]
     fn offset_simple() {
         #[repr(C)]


### PR DESCRIPTION
This code is for tests and is to line up and draw attention to the offsets. Better to suppress than eliminate.