### PR TITLE
Just use core::mem::offset_of!() on rustc >= 1.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
  - Clarify documentation about macro indirection
  - Added changelog
+ - Turn the crate into a thin stdlib wrapper on rustc>=1.77
+ - Remove `unstable_offset_of`
 
 ## v0.9.0 (18/05/2023)
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,3 @@ doc-comment = "0.3"
 [features]
 default = []
 unstable_const = []
-unstable_offset_of = []

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Introduces the following macros:
 
 `memoffset` works under `no_std` environments.
 
+If you're using a rustc version greater or equal to 1.77, this crate's `offset_of!()` macro simply forwards to `core::mem::offset_of!()`.
+
 ## Usage ##
 Add the following dependency to your `Cargo.toml`:
 
@@ -53,13 +55,11 @@ fn main() {
 Constant evaluation is automatically enabled and available on stable compilers starting with rustc 1.65.
 
 This is an incomplete implementation with one caveat:
-Due to dependence on [`#![feature(const_refs_to_cell)]`](https://github.com/rust-lang/rust/issues/80384), you cannot get the offset of a `Cell` field in a const-context.
+Due to dependence on [`#![feature(const_refs_to_cell)]`](https://github.com/rust-lang/rust/issues/80384), you cannot get the offset of a `Cell` field in a const-context on a rustc version less than 1.77.
 
-This means that if need to get the offset of a cell, you'll have to remain on nightly for now.
+### Usage on somewhat recent nightlies ###
 
-### Usage on recent nightlies ###
-
-If you're using a new-enough nightly and you require the ability to get the offset of a `Cell`,
+If you're using a nightly that does not yet have `core::mem::offset_of!()` and you require the ability to get the offset of a `Cell`,
 you'll have to enable the `unstable_const` cargo feature, as well as enabling `const_refs_to_cell` in your crate root.
 
 Do note that `unstable_const` is an unstable feature that is set to be removed in a future version of `memoffset`.

--- a/build.rs
+++ b/build.rs
@@ -22,4 +22,7 @@ fn main() {
     if ac.probe_rustc_version(1, 65) {
         println!("cargo:rustc-cfg=stable_const");
     }
+    if ac.probe_rustc_version(1, 77) {
+        println!("cargo:rustc-cfg=stable_offset_of");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,10 @@
     feature(const_ptr_offset_from)
 )]
 #![cfg_attr(feature = "unstable_const", feature(const_refs_to_cell))]
-#![cfg_attr(feature = "unstable_offset_of", feature(allow_internal_unstable))]
+#![cfg_attr(
+    all(feature = "unstable_offset_of", not(stable_offset_of)),
+    feature(allow_internal_unstable)
+)]
 
 #[macro_use]
 #[cfg(doctests)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,6 @@
     feature(const_ptr_offset_from)
 )]
 #![cfg_attr(feature = "unstable_const", feature(const_refs_to_cell))]
-#![cfg_attr(
-    all(feature = "unstable_offset_of", not(stable_offset_of)),
-    feature(allow_internal_unstable)
-)]
 
 #[macro_use]
 #[cfg(doctests)]

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -67,7 +67,7 @@ macro_rules! _memoffset_offset_from_unsafe {
         ($field as usize) - ($base as usize)
     };
 }
-#[cfg(not(any(feature = "unstable_offset_of", stable_offset_of)))]
+#[cfg(not(stable_offset_of))]
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! _memoffset__offset_of_impl {
@@ -80,13 +80,9 @@ macro_rules! _memoffset__offset_of_impl {
         _memoffset_offset_from_unsafe!(field_ptr, base_ptr)
     }};
 }
-#[cfg(any(feature = "unstable_offset_of", stable_offset_of))]
+#[cfg(stable_offset_of)]
 #[macro_export]
 #[doc(hidden)]
-#[cfg_attr(
-    all(feature = "unstable_offset_of", not(stable_offset_of)),
-    allow_internal_unstable(offset_of)
-)]
 macro_rules! _memoffset__offset_of_impl {
     ($parent:path, $field:tt) => {{
         $crate::__priv::mem::offset_of!($parent, $field)
@@ -129,7 +125,7 @@ macro_rules! offset_of {
 }
 
 #[cfg(tuple_ty)]
-#[cfg(not(any(feature = "unstable_offset_of", stable_offset_of)))]
+#[cfg(not(stable_offset_of))]
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! _memoffset__offset_of_tuple_impl {
@@ -144,13 +140,9 @@ macro_rules! _memoffset__offset_of_tuple_impl {
 }
 
 #[cfg(tuple_ty)]
-#[cfg(any(feature = "unstable_offset_of", stable_offset_of))]
+#[cfg(stable_offset_of)]
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
-#[cfg_attr(
-    all(feature = "unstable_offset_of", not(stable_offset_of)),
-    allow_internal_unstable(offset_of)
-)]
 macro_rules! _memoffset__offset_of_tuple_impl {
     ($parent:ty, $field:tt) => {{
         $crate::__priv::mem::offset_of!($parent, $field)
@@ -175,7 +167,7 @@ macro_rules! offset_of_tuple {
     }};
 }
 
-#[cfg(not(any(feature = "unstable_offset_of", stable_offset_of)))]
+#[cfg(not(stable_offset_of))]
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! _memoffset__offset_of_union_impl {
@@ -189,13 +181,9 @@ macro_rules! _memoffset__offset_of_union_impl {
     }};
 }
 
-#[cfg(any(feature = "unstable_offset_of", stable_offset_of))]
+#[cfg(stable_offset_of)]
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
-#[cfg_attr(
-    all(feature = "unstable_offset_of", not(stable_offset_of)),
-    allow_internal_unstable(offset_of)
-)]
 macro_rules! _memoffset__offset_of_union_impl {
     ($parent:path, $field:tt) => {{
         $crate::__priv::mem::offset_of!($parent, $field)
@@ -380,11 +368,7 @@ mod tests {
         assert_eq!(f_ptr as usize + 0, raw_field_union!(f_ptr, Foo, c) as usize);
     }
 
-    #[cfg(any(
-        feature = "unstable_const",
-        any(feature = "unstable_offset_of", stable_offset_of),
-        stable_const
-    ))]
+    #[cfg(any(feature = "unstable_const", stable_offset_of, stable_const))]
     #[test]
     fn const_offset() {
         #[repr(C)]
@@ -409,11 +393,7 @@ mod tests {
         assert_eq!([0; offset_of!(Foo, b)].len(), 4);
     }
 
-    #[cfg(any(
-        feature = "unstable_const",
-        any(feature = "unstable_offset_of", stable_offset_of),
-        stable_const
-    ))]
+    #[cfg(any(feature = "unstable_const", stable_offset_of, stable_const))]
     #[test]
     fn const_fn_offset() {
         const fn test_fn() -> usize {


### PR DESCRIPTION
Stable `mem::offset_of!()`, yay!

I'm unsure about the README changes, maybe those old nightly instructions are just not needed at all anymore?