### PR TITLE
stub out unstable_const feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,20 +47,6 @@ jobs:
         # with backwards compatibility workarounds.
         run: cargo test --lib
 
-  nightly:
-    name: Test Suite (nightly features)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-      - name: Run cargo test
-        # `--lib` prevents doctests from being run.
-        # This is due to `unstable_const` requiring extra `feature(...)` directives
-        # which the doctests do not have.
-        run: cargo test --all-features --lib
-
   miri:
     name: Test Suite (Miri)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
           - 1.51.0  # Oldest supported with ptr::addr_of!
           - 1.65.0  # Oldest supported with stable const evaluation (sans cell)
           - 1.77.0  # Oldest supported with native `offset_of!`
-          - stable
-          - beta
-          - nightly
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - 1.40.0  # Oldest supported with cfg(doctest)
           - 1.51.0  # Oldest supported with ptr::addr_of!
           - 1.65.0  # Oldest supported with stable const evaluation (sans cell)
+          - 1.77.0  # Oldest supported with native `offset_of!`
           - stable
           - beta
           - nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Test with Miri
         run: |
           cargo miri test
-          cargo miri test --all-features
 
   style:
     name: lints and formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
  - Clarify documentation about macro indirection
  - Added changelog
  - Turn the crate into a thin stdlib wrapper on rustc>=1.77
- - Remove `unstable_offset_of` and `unstable_const`; they are not needed any more on recent nightlies
+ - Turn `unstable_offset_of` and `unstable_const` into NOPs; they are not needed any more on recent nightlies
 
 ## v0.9.0 (18/05/2023)
 ### Added
- - Cargo feature `unstable_offset_of` which turns the crate into an stdlib polyfill
+ - Cargo feature `unstable_offset_of` which turns the crate into a stdlib polyfill
 
 ## v0.8.0 (15/12/2022)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  - Clarify documentation about macro indirection
  - Added changelog
  - Turn the crate into a thin stdlib wrapper on rustc>=1.77
- - Remove `unstable_offset_of`
+ - Remove `unstable_offset_of` and `unstable_const`; they are not needed any more on recent nightlies
 
 ## v0.9.0 (18/05/2023)
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,3 @@ autocfg = "1"
 
 [dev-dependencies]
 doc-comment = "0.3"
-
-[features]
-default = []
-unstable_const = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,9 @@ autocfg = "1"
 
 [dev-dependencies]
 doc-comment = "0.3"
+
+[features]
+default = []
+# NOP features, solely so that people do not have to change their Cargo.toml
+unstable_offset_of = []
+unstable_const = []

--- a/README.md
+++ b/README.md
@@ -49,37 +49,7 @@ fn main() {
 ```
 
 ## Usage in constants ##
-`memoffset` has support for compile-time `offset_of!` on rust>=1.65, or on older nightly compilers.
+`memoffset` has support for compile-time `offset_of!` on rust>=1.65.
 
-### Usage on stable Rust ###
-Constant evaluation is automatically enabled and available on stable compilers starting with rustc 1.65.
-
-This is an incomplete implementation with one caveat:
-Due to dependence on [`#![feature(const_refs_to_cell)]`](https://github.com/rust-lang/rust/issues/80384), you cannot get the offset of a `Cell` field in a const-context on a rustc version less than 1.77.
-
-### Usage on somewhat recent nightlies ###
-
-If you're using a nightly that does not yet have `core::mem::offset_of!()` and you require the ability to get the offset of a `Cell`,
-you'll have to enable the `unstable_const` cargo feature, as well as enabling `const_refs_to_cell` in your crate root.
-
-Do note that `unstable_const` is an unstable feature that is set to be removed in a future version of `memoffset`.
-
-Cargo.toml:
-```toml
-[dependencies.memoffset]
-version = "0.9"
-features = ["unstable_const"]
-```
-
-Your crate root: (`lib.rs`/`main.rs`)
-```rust,ignore
-#![feature(const_refs_to_cell)]
-```
-
-### Usage on older nightlies ###
-In order to use it on an older nightly compiler, you must enable the `unstable_const` crate feature and several compiler features.
-
-Your crate root: (`lib.rs`/`main.rs`)
-```rust,ignore
-#![feature(const_ptr_offset_from, const_refs_to_cell)]
-```
+On versions below 1.77, this is an incomplete implementation with one caveat:
+Due to dependence on [`#![feature(const_refs_to_cell)]`](https://github.com/rust-lang/rust/issues/80384), you cannot get the offset of a `Cell` field in a const-context.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,11 +54,6 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(
-    all(feature = "unstable_const", not(stable_const)),
-    feature(const_ptr_offset_from)
-)]
-#![cfg_attr(feature = "unstable_const", feature(const_refs_to_cell))]
 
 #[macro_use]
 #[cfg(doctests)]

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -237,7 +237,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // this creates unaligned references
     fn offset_simple_packed() {
         #[repr(C, packed)]
         struct Foo {

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -46,7 +46,7 @@ macro_rules! _memoffset__let_base_ptr {
 }
 
 /// Macro to compute the distance between two pointers.
-#[cfg(any(feature = "unstable_const", stable_const))]
+#[cfg(stable_const)]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! _memoffset_offset_from_unsafe {
@@ -58,7 +58,7 @@ macro_rules! _memoffset_offset_from_unsafe {
         unsafe { (field as *const u8).offset_from(base as *const u8) as usize }
     }};
 }
-#[cfg(not(any(feature = "unstable_const", stable_const)))]
+#[cfg(not(stable_const))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! _memoffset_offset_from_unsafe {
@@ -368,7 +368,7 @@ mod tests {
         assert_eq!(f_ptr as usize + 0, raw_field_union!(f_ptr, Foo, c) as usize);
     }
 
-    #[cfg(any(feature = "unstable_const", stable_offset_of, stable_const))]
+    #[cfg(any(stable_offset_of, stable_const))]
     #[test]
     fn const_offset() {
         #[repr(C)]
@@ -381,7 +381,7 @@ mod tests {
         assert_eq!([0; offset_of!(Foo, b)].len(), 4);
     }
 
-    #[cfg(feature = "unstable_const")]
+    #[cfg(stable_offset_of)]
     #[test]
     fn const_offset_interior_mutable() {
         #[repr(C)]
@@ -393,7 +393,7 @@ mod tests {
         assert_eq!([0; offset_of!(Foo, b)].len(), 4);
     }
 
-    #[cfg(any(feature = "unstable_const", stable_offset_of, stable_const))]
+    #[cfg(any(stable_offset_of, stable_const))]
     #[test]
     fn const_fn_offset() {
         const fn test_fn() -> usize {


### PR DESCRIPTION
It is pointless, nightly users get `stable_offset_of` which switches out the entire implementation and makes it fully const-compatible without any nightly feature.

However we can avoid breaking the build of people that enable this feature, by simply making it do nothing. If they are on a ~recent nightly (less than 3 months old), they will get `stable_offset_of` which subsumes all the unstable features. If they are on an older nightly they should stick to older versions of memoffset.